### PR TITLE
Add PR draft command for confirmed findings

### DIFF
--- a/argo/cli.py
+++ b/argo/cli.py
@@ -432,6 +432,28 @@ def report(run: str = RunIdArg, runner: str = RunnerOpt,
     _emit({"run_id": run, "report": str(path), "drafts_dir": str(ctx.drafts_dir)})
 
 
+@app.command(name="pr-draft")
+def pr_draft(run: str = RunIdArg,
+             finding: str = typer.Option(..., "--finding", help="confirmed finding id to draft for"),
+             test_command: Optional[str] = typer.Option(
+                 None, "--test-command", help="local build/test command to include in the PR body"),
+             runner: str = RunnerOpt, audit_model: Optional[str] = AuditModelOpt,
+             calibration: bool = CalibrationOpt, budget: Optional[float] = BudgetOpt,
+             parallel: int = ParallelOpt, runs_dir: Path = RunsDirOpt, scenario: str = ScenarioOpt):
+    """Write a maintainer-facing GitHub PR body scaffold for one confirmed finding.
+
+    This is a local artifact only; Argo still never opens or submits a PR.
+    """
+    from .stages.report import write_pr_draft
+    cfg = _build_config(runner, audit_model, calibration, budget, parallel, runs_dir, scenario)
+    ctx = build_context(cfg, run)
+    try:
+        path = write_pr_draft(ctx, finding, test_command=test_command)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _emit({"run_id": run, "finding": finding, "pr_draft": str(path)})
+
+
 @app.command()
 def resume(
     run: str = RunIdArg,

--- a/argo/stages/report.py
+++ b/argo/stages/report.py
@@ -108,6 +108,15 @@ def run(ctx: RunContext) -> Path:
     return report_path
 
 
+def write_pr_draft(ctx: RunContext, finding_id: str, test_command: str | None = None) -> Path:
+    """Write a maintainer-facing GitHub PR body scaffold for one confirmed finding."""
+    out_dir = ctx.run_dir / "pr_drafts"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{finding_id}.md"
+    path.write_text(render_pr_draft(ctx, finding_id, test_command=test_command), encoding="utf-8")
+    return path
+
+
 # ------------------------------------------------------------------------- rendering
 def _counts_by_severity(findings: list[dict]) -> dict[str, int]:
     counts = {s: 0 for s in SEVERITY_ORDER}
@@ -431,6 +440,55 @@ def _render_draft(ctx, scope, f: dict) -> str:
         L.append("")
     L.append("---")
     L.append("**DRAFT - verify before submitting. No live testing was performed by the pipeline.**")
+    L.append("")
+    return "\n".join(L)
+
+
+def render_pr_draft(ctx: RunContext, finding_id: str, test_command: str | None = None) -> str:
+    scope = ctx.load_scope()
+    doc = json.loads(ctx.validated_findings_path.read_text(encoding="utf-8-sig"))
+    finding = next((f for f in doc.get("findings", []) if f.get("id") == finding_id), None)
+    if finding is None:
+        raise ValueError(f"finding {finding_id!r} was not found in validated_findings.json")
+    if _verdict(finding) != "confirmed":
+        raise ValueError(f"finding {finding_id!r} is not confirmed; PR drafts are for confirmed findings")
+    if _corr_verdict(finding) == "design_accepted":
+        raise ValueError(f"finding {finding_id!r} is documented as an accepted design risk")
+
+    affected = finding.get("affected") or []
+    affected_text = ", ".join(f"`{item}`" for item in affected) or "_Add affected files._"
+    test_text = f"`{test_command}`" if test_command else "_Replace with the exact local test/build command you ran._"
+    L: list[str] = []
+    L.append(f"# Draft PR body - {finding.get('title')}")
+    L.append("")
+    L.append("> Human-edit before opening a PR: describe the final patch and paste real test output. ")
+    L.append("> Argo generated this from a confirmed source-static finding; it did not submit anything.")
+    L.append("")
+    L.append("## What does this PR do?")
+    L.append("")
+    L.append(f"Addresses **{finding.get('title')}** in {affected_text}.")
+    L.append("")
+    L.append(f"Root cause: {finding.get('why_vulnerable', '')}")
+    L.append("")
+    L.append(f"Recommended fix direction: {finding.get('recommended_fix', '')}")
+    L.append("")
+    L.append("## Why is it important?")
+    L.append("")
+    L.append(f"Impact: {finding.get('impact', '')}")
+    L.append("")
+    L.append(f"Validated flow: {_validation_field(finding, 'surviving_data_flow') or finding.get('vulnerable_flow', '')}")
+    L.append("")
+    L.append("## How was this checked?")
+    L.append("")
+    L.append(f"- Argo run: `{ctx.run_id}` against `{scope.program_name}`")
+    L.append(f"- Verdict: `{_verdict(finding)}`; severity: `{_eff_sev(finding)}`; confidence: `{_eff_conf(finding)}`")
+    L.append(f"- Local validation command: {test_text}")
+    L.append("- Regression expectation: the vulnerable flow above is rejected or safely handled after this patch.")
+    L.append("")
+    L.append("## Safety notes")
+    L.append("")
+    L.append("- Argo performed source-static analysis only; no live hosts were contacted.")
+    L.append("- This draft is for a human-authored PR after implementing and testing a fix.")
     L.append("")
     return "\n".join(L)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,6 +27,7 @@ Everywhere below, `argo` ≡ `python -m argo.cli`.
 | `runtime` | RUNTIME | **opt-in** sandboxed runtime verification: build the target in an egress-blocked, loopback-only container and probe ONLY the local instance (never live hosts) → `runtime_results.json`. See [runtime-verification-study.md](runtime-verification-study.md) |
 | `live` | LIVE | ⚠️ **opt-in, default off, AUTHORIZED USE ONLY.** Bounded **read-only** requests to the program's **in-scope** hosts to confirm findings. Requires `--i-have-authorization`; RoE-gated (automation/safe-harbor/prohibited), in-scope-only (out-of-scope/unknown blocked), capped + audit-logged. Uses a hand-written `runs/<id>/live_probe_plan.json` if present, else (L2) an **offline** LLM generates one from the validated findings (same gates apply) and interprets the results → `live_results.json` + `live_audit_log.jsonl` (+ a `validation.live` block on findings). See [guardrails §2c](guardrails.md#2c-the-opt-in-live-exception-the-live-stage-in-scope-hosts-only) |
 | `report` | 5 | `REPORT.md` + DRAFT submissions |
+| `pr-draft` | post-report | maintainer-facing GitHub PR body scaffold for one confirmed finding; local artifact only, never submits |
 | `pipeline` | 1–5 | the whole chain; **stops before any submission** |
 | `fix` | 6 (opt-in) | propose + **verify** a patch per confirmed finding (applies? compiles? no new errors?); never touches the target |
 | `bench` | 7 | score a labeled suite — findings precision/recall/F1 by archetype + CWE (+ optional A/B and patch quality) |
@@ -43,6 +44,7 @@ argo run      --run RUN_ID
 argo sca      --run RUN_ID
 argo validate --run RUN_ID
 argo report   --run RUN_ID
+argo pr-draft --run RUN_ID --finding FINDING_ID [--test-command "CMD"]
 argo pipeline --repo PATH_OR_URL [--brief BRIEF.txt] [--links LINKS.txt] [--commit SHA] [--dry-run] [--smoke]
 argo fix      --run RUN_ID [--no-verify] [--re-audit] [--docker IMAGE] [--build-cmd "CMD"] [--only ID,ID]
 argo bench    --suite DIR [--fixes] [--re-audit] [--parallel-cases N] [--ab-audit-model MODEL]
@@ -110,6 +112,18 @@ argo quality  [--program P] [--runs-dir DIR]
 | `--critic-passes N` | completeness-critic re-passes per audit focus (the depth lever — re-audits each focus for missed variant-family members / unverified invariants, looping until dry). **Default 1**; `0` disables. |
 | `--dry-run` | run ingest + recon, then **stop before any audit**. The prompt-quality feedback loop: inspect the generated prompts (incl. the ground-truth sections) before paying to run them. |
 | `--smoke` | de-risked **real** end-to-end check: cheapest models, one audit focus, low budget + short timeout + tight caps. Defaults `--brief`/`--repo` to the bundled fixtures (and forces `--no-research`). See [headless-runner.md](headless-runner.md#the---smoke-run). |
+
+## `pr-draft` options
+
+| Flag | Meaning |
+|---|---|
+| `--finding ID` | confirmed finding id from `validated_findings.json` to turn into a GitHub PR body scaffold |
+| `--test-command "CMD"` | optional local build/test command to include in the draft's validation section |
+
+`pr-draft` writes `runs/<RUN_ID>/pr_drafts/<ID>.md`. It is meant for the OSS-maintainer flow:
+after you implement and locally test a fix, use the scaffold as the starting point for a clear PR
+body with what changed, why it matters, and how it was checked. It refuses unconfirmed findings and
+does not open or submit anything.
 
 ## `fix`-only options (Phase 6 remediation)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -182,6 +182,28 @@ def test_drafts_only_for_confirmed(env):
     assert drafts == {"FULL-001", "AUTHZ-002"}
 
 
+def test_pr_draft_for_confirmed_finding(env):
+    from argo.stages.report import write_pr_draft
+    ctx = env()
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    path = write_pr_draft(ctx, "AUTHZ-002", test_command="pytest tests/test_orders.py -q")
+    text = path.read_text(encoding="utf-8")
+    assert path == ctx.run_dir / "pr_drafts" / "AUTHZ-002.md"
+    assert "# Draft PR body - IDOR: order access without ownership check" in text
+    assert "## What does this PR do?" in text
+    assert "`pytest tests/test_orders.py -q`" in text
+    assert "no live hosts were contacted" in text
+
+
+def test_pr_draft_rejects_unconfirmed_finding(env):
+    from argo.stages.report import write_pr_draft
+    import pytest
+    ctx = env()
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    with pytest.raises(ValueError, match="not confirmed"):
+        write_pr_draft(ctx, "FULL-003")
+
+
 # --------------------------------------------------------------------------- fallbacks
 def test_missing_manifest_recon_glob_fallback(env, make_scenario):
     fixtures_dir, scen = make_scenario(


### PR DESCRIPTION
## What & why

Adds a local `pr-draft` command that turns one confirmed Argo finding into a maintainer-facing GitHub PR body scaffold. This supports the OSS disclosure/remediation flow: after a user implements and tests a fix, they can start from a clear `what / why / how checked` PR body similar to the public security-fix writeups Argo already helps produce.

The command writes `runs/<RUN_ID>/pr_drafts/<FINDING_ID>.md` and does not open, submit, or mutate anything outside local run artifacts, preserving Argo's no-submit guardrail.

## Changes

- Add deterministic `render_pr_draft()` / `write_pr_draft()` helpers in the report stage
- Add `python -m argo.cli pr-draft --run RUN_ID --finding FINDING_ID [--test-command "CMD"]`
- Refuse missing, unconfirmed, or design-accepted findings
- Document the command in the CLI reference
- Add focused tests for confirmed and unconfirmed findings

## Testing

- `python -m pytest tests/test_pipeline.py -q` -> 21 passed
- `python -m argo.cli pr-draft --help` -> renders command help successfully
- `python -m pytest tests/ -q` -> 322 passed, 1 skipped; 4 existing headless-runner tests fail in this environment because `claude` is not installed on PATH, before exercising this change