### PR TITLE
corroborate: self-apply design_accepted when rationale contradicts verdict

### DIFF
--- a/argo/models.py
+++ b/argo/models.py
@@ -95,6 +95,13 @@ class Corroboration(BaseModel):
     fix_commit: Optional[str] = None        # commit SHA / PR / release tag that fixed it (fixed_upstream)
     doc_url: Optional[str] = None           # the doc page that documents the behavior (design_accepted)
     adjusted_severity: Optional[Severity] = None   # optional downgrade (e.g. design_accepted -> Low)
+    # Set only when the deterministic self-consistency check in stages/corroborate.py overrode the
+    # model's own stated verdict, because ``rationale`` described the behavior as vendor-documented/
+    # intended while ``verdict`` said something else (a real LLM self-contradiction, not a code bug —
+    # 2/27 gitea findings did exactly this on 2026-07-22 and nearly shipped as new vulnerabilities
+    # until a human caught it by hand). Preserves what the model actually output for transparency;
+    # never silently substituted. See ``corroborate._reconcile_verdict_with_rationale``.
+    verdict_overridden_from: Optional[CorroborationVerdict] = None
 
 
 class Verification(BaseModel):

--- a/argo/prompts/08_corroborate_prompt.md
+++ b/argo/prompts/08_corroborate_prompt.md
@@ -34,6 +34,12 @@ already fixed, and reporting a documented "by design" decision as a vulnerabilit
   docs and commits: maintainers of the same behavior being reported repeatedly and dismissed as
   intended is strong `design_accepted` evidence (cite the issue/PR/discussion URL).
 - Keep it bounded: roughly **{{MAX_SEARCHES}} web searches** for this finding is plenty.
+- **Your `verdict` and your `rationale` must never contradict each other.** If your rationale states
+  or clearly implies that the behavior is vendor-documented, intentional, or an accepted design
+  decision, your `verdict` MUST be `design_accepted` — do not write a rationale describing intended/
+  documented behavior while still returning `corroborated`. This has happened before and nearly
+  caused a documented-as-intended behavior to be reported as a new vulnerability; re-read your own
+  rationale before picking the verdict field, not the other way around.
 
 ## THE FINDING
 The audit ran against this version of the source (corroborate against newer history if any exists):

--- a/argo/prompts/08b_corroborate_batch_prompt.md
+++ b/argo/prompts/08b_corroborate_batch_prompt.md
@@ -24,6 +24,11 @@ Handle each finding on its own evidence — do not let one finding's verdict inf
 - Search the **issue tracker, PRs, and discussions** (open AND closed), not only docs/commits — a
   behavior repeatedly reported and dismissed as intended is strong `design_accepted` evidence.
 - Keep it bounded: roughly **{{MAX_SEARCHES}} web searches PER FINDING** is plenty.
+- **Each finding's `verdict` and `rationale` must never contradict each other.** If a rationale
+  states or clearly implies vendor-documented/intentional/accepted-design behavior, that finding's
+  `verdict` MUST be `design_accepted` — never write a rationale describing intended/documented
+  behavior while returning `corroborated` for the same item. Re-read each rationale before picking
+  its verdict field, not the other way around.
 
 ## CONTEXT
 The audit ran against this version of the source (corroborate against newer history if any exists):

--- a/argo/stages/corroborate.py
+++ b/argo/stages/corroborate.py
@@ -16,6 +16,12 @@ Guardrails (defense in depth):
     passed as excerpts in the prompt (network OR repo, never both in one session).
   * It must NEVER contact the program's live in-scope hosts (passed as a forbidden list, like research).
   * Best-effort: a failure here never fails the run — the finding is simply left ``unknown``.
+  * Self-consistency backstop: the model occasionally writes a ``rationale`` that itself asserts
+    vendor-confirmed/documented intent while leaving ``verdict`` at ``corroborated`` — a real
+    contradiction seen in production (2/27 gitea findings, 2026-07-22), not a hypothetical. A
+    deterministic, high-precision phrase check (``_reconcile_verdict_with_rationale``) catches this
+    and corrects the verdict, preserving the model's original call in
+    ``verdict_overridden_from`` for transparency rather than silently substituting it.
 """
 
 from __future__ import annotations
@@ -51,6 +57,51 @@ _INFRA_FAILURE_RATIONALE_PREFIXES = (
 def _is_infra_failure(corr: Corroboration) -> bool:
     return (corr.verdict == "unknown" and bool(corr.rationale)
             and corr.rationale.startswith(_INFRA_FAILURE_RATIONALE_PREFIXES))
+
+
+# Self-consistency backstop for a real, observed LLM failure mode: the model's free-text ``rationale``
+# correctly identifies and cites vendor documentation proving a behavior is intentional, but the
+# structured ``verdict`` field it outputs alongside that same rationale still says "corroborated" — a
+# contradiction between what the model wrote and what it clicked, not a code-plumbing bug. Found
+# 2026-07-22 on gitea (CRYPTO-TOKEN-002, SSRF-001): both were about to ship as new vulnerabilities in
+# a disclosure until a human re-read all 27 rationales by hand and caught the mismatch. The primary
+# fix is prompting the model to keep verdict and rationale consistent (see 08_corroborate_prompt.md /
+# 08b_corroborate_batch_prompt.md); this is the deterministic safety net for when that still slips
+# through. Deliberately a SHORT, high-precision phrase list, not a broad keyword scan — a false
+# positive here (wrongly downgrading a real vulnerability to design_accepted) is a worse outcome than
+# the false negative it's meant to catch, so every phrase is one that essentially only appears when a
+# rationale is actually asserting vendor-confirmed intent, not describing a design constraint the
+# vulnerability violates.
+_DESIGN_ACCEPTED_SIGNALS = (
+    "documented as intended",
+    "documented as intentional",
+    "intended, documented behavior",
+    "confirmed intentional",
+    "vendor confirms this is intended",
+    "vendor documentation confirms this is intended",
+    "explicitly documented as intended",
+    "is a documented design decision",
+    "is an accepted design decision",
+    "accepted risk per",
+    "known, accepted limitation",
+    "matches the vendor's documented threat model",
+)
+
+
+def _reconcile_verdict_with_rationale(corr: Corroboration) -> Corroboration:
+    """If ``rationale`` strongly asserts vendor-confirmed/documented intent while ``verdict`` is
+    anything other than ``design_accepted``, correct the verdict — but never silently: the model's
+    own original verdict is preserved in ``verdict_overridden_from`` so a human reviewing the report
+    can see exactly what happened and double-check the call (see the module-level note above)."""
+    if corr.verdict == "design_accepted" or corr.verdict == "fixed_upstream" or not corr.rationale:
+        return corr
+    text = corr.rationale.lower()
+    if any(sig in text for sig in _DESIGN_ACCEPTED_SIGNALS):
+        return corr.model_copy(update={
+            "verdict": "design_accepted",
+            "verdict_overridden_from": corr.verdict,
+        })
+    return corr
 
 
 def _log(msg: str) -> None:
@@ -255,9 +306,16 @@ def run(ctx: RunContext) -> Path:
     fixed_upstream: list[dict] = []
     counts = {"corroborated": 0, "design_accepted": 0, "fixed_upstream": 0, "unknown": 0}
     infra_failure_unknown = 0
+    overridden = 0
     for f in survivors:
         corr = verdicts.get(f.id)
         if corr is not None:
+            corr = _reconcile_verdict_with_rationale(corr)
+            if corr.verdict_overridden_from is not None:
+                overridden += 1
+                _log(f"{f.id}: verdict self-corrected "
+                     f"{corr.verdict_overridden_from} -> design_accepted "
+                     f"(rationale asserted vendor-confirmed intent)")
             f.corroboration = corr
             counts[corr.verdict] = counts.get(corr.verdict, 0) + 1
             if corr.verdict == "unknown" and _is_infra_failure(corr):
@@ -282,6 +340,7 @@ def run(ctx: RunContext) -> Path:
     # a corroboration-quality problem in the gguf-tools run that first prompted this split.
     stats["unknown_due_to_infra_failure"] = infra_failure_unknown
     stats["unknown_genuine"] = counts["unknown"] - infra_failure_unknown
+    stats["verdict_self_corrected"] = overridden
     ctx.validated_findings_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
     unknown_breakdown = (
         f"{counts['unknown']} unknown ({infra_failure_unknown} due to session/backend failure — "
@@ -289,7 +348,8 @@ def run(ctx: RunContext) -> Path:
         f"{counts['unknown'] - infra_failure_unknown} genuinely inconclusive)"
         if infra_failure_unknown else f"{counts['unknown']} unknown"
     )
-    _log(f"{counts['corroborated']} corroborated, {counts['design_accepted']} design-accepted, "
+    override_note = f" ({overridden} verdict-self-corrected)" if overridden else ""
+    _log(f"{counts['corroborated']} corroborated, {counts['design_accepted']} design-accepted{override_note}, "
          f"{len(fixed_upstream)} fixed-upstream, {unknown_breakdown} "
          f"-> {len(kept)} active survivor(s)")
     return ctx.validated_findings_path

--- a/argo/stages/report.py
+++ b/argo/stages/report.py
@@ -366,6 +366,11 @@ def _finding_section(f: dict) -> list[str]:
         elif ev:
             line += f" Evidence: {ev[0]}"
         L.append(line)
+        if corr.get("verdict_overridden_from"):
+            L.append(f"> ⚠️ Verdict auto-corrected from `{corr['verdict_overridden_from']}` to "
+                      f"`design_accepted`: the model's own rationale above asserted vendor-confirmed/"
+                      f"documented intent, but its structured verdict initially said otherwise. "
+                      f"Double-check this call before relying on it.")
         L.append("")
     verf = f.get("verification") or {}
     if verf.get("verdict"):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,18 @@ Corroborate additionally mines the issue tracker for prior "by design / wontfix"
 hardest false-positive modes at the source, complementing corroborate (which catches the
 documented/already-fixed cases after the fact).
 
+**Corroborate's own verdict/rationale self-consistency backstop.** The model corroborating a
+finding occasionally writes a `rationale` that itself asserts vendor-confirmed/documented intent
+while the structured `verdict` it outputs alongside that same rationale still says `corroborated` —
+a genuine contradiction between what the model wrote and what it selected, observed in production
+(2/27 findings on one target nearly shipped as new vulnerabilities before a human caught the
+mismatch by hand). The prompt now explicitly instructs the model to keep verdict and rationale
+consistent; a deterministic, high-precision phrase check (`corroborate._reconcile_verdict_with_rationale`)
+is a backstop for when that instruction alone isn't enough — it corrects the verdict to
+`design_accepted` when the rationale clearly asserts it, and preserves the model's original call in
+`corroboration.verdict_overridden_from` so nothing is silently substituted (surfaced in `REPORT.md`
+with an explicit "auto-corrected" note for human review).
+
 **Deep verify: why a separate stage from validate.** Validate is adversarial but structurally
 *isolates* each finding — its prompt explicitly forbids one finding's verdict from influencing
 another's, so it can never notice that finding A and finding B are the same bug reached two ways,

--- a/tests/test_corroborate.py
+++ b/tests/test_corroborate.py
@@ -92,6 +92,53 @@ def test_design_accepted_kept_but_no_draft(env, make_scenario):
     assert "Vendor-documented design decision" in report
 
 
+# ------------------------------------------------------------- verdict self-consistency backstop
+def test_verdict_self_corrected_when_rationale_asserts_design_accepted(env, make_scenario):
+    """The model can (and, once for real on gitea, did) write a rationale that itself asserts
+    vendor-confirmed intent while leaving verdict at "corroborated" — a genuine self-contradiction.
+    The deterministic backstop must catch this, correct the verdict, and preserve the original call."""
+    fixtures_dir, scen = make_scenario(
+        lambda d: _corr_fixture(d, "AUTHZ-002", {
+            "finding_id": "AUTHZ-002", "verdict": "corroborated",
+            "rationale": "The GitHub issue tracker shows this is documented as intended by the "
+                         "maintainers; see issue #42.",
+        }),
+        name="selfcontradict")
+    ctx = env(scen, fixtures_dir=fixtures_dir, corroborate_enabled=True)
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    vf = _validated(ctx)
+    kept = {f["id"]: f for f in vf["findings"]}
+    corr = kept["AUTHZ-002"]["corroboration"]
+    assert corr["verdict"] == "design_accepted"                  # corrected, not left at corroborated
+    assert corr["verdict_overridden_from"] == "corroborated"     # original call preserved, not lost
+    assert vf["stats"]["verdict_self_corrected"] == 1
+    # no submission draft for a (corrected) design_accepted finding
+    assert "AUTHZ-002" not in {p.stem for p in ctx.drafts_dir.glob("*.md")}
+    report = (ctx.run_dir / "REPORT.md").read_text(encoding="utf-8")
+    assert "auto-corrected from `corroborated` to `design_accepted`" in report
+
+
+def test_verdict_not_corrected_for_an_ordinary_corroborated_rationale(env, make_scenario):
+    """Precision check: a rationale that merely mentions "documentation" in passing (without
+    asserting the behavior itself is vendor-confirmed as intended) must NOT trigger the backstop —
+    a false positive here would wrongly downgrade a real, still-open vulnerability."""
+    fixtures_dir, scen = make_scenario(
+        lambda d: _corr_fixture(d, "AUTHZ-002", {
+            "finding_id": "AUTHZ-002", "verdict": "corroborated",
+            "rationale": "The documentation does not mention this behavior anywhere, and no "
+                         "issue or PR addresses it, so it still appears to be a real, unaddressed bug.",
+        }),
+        name="notriggerfp")
+    ctx = env(scen, fixtures_dir=fixtures_dir, corroborate_enabled=True)
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    vf = _validated(ctx)
+    kept = {f["id"]: f for f in vf["findings"]}
+    corr = kept["AUTHZ-002"]["corroboration"]
+    assert corr["verdict"] == "corroborated"
+    assert corr.get("verdict_overridden_from") is None
+    assert vf["stats"]["verdict_self_corrected"] == 0
+
+
 # --------------------------------------------------------------------------- best effort
 def test_bad_verdict_coerced_to_unknown(env, make_scenario):
     fixtures_dir, scen = make_scenario(


### PR DESCRIPTION
## Summary
- Corroborate's own free-text rationale sometimes correctly identifies vendor-confirmed/documented intent while the structured `verdict` field stays `corroborated` — a real self-contradiction (2/27 gitea findings did this and nearly shipped as new vulnerabilities before a human caught it by hand on 2026-07-22).
- Strengthens both corroborate prompts (single + batch) to explicitly require verdict/rationale consistency.
- Adds a deterministic, high-precision phrase-based backstop (`_reconcile_verdict_with_rationale`) for when the prompt instruction alone isn't enough — corrects the verdict to `design_accepted`, preserving the model's original call in the new `Corroboration.verdict_overridden_from` field (never silently substituted).
- `REPORT.md` now surfaces an explicit "auto-corrected" note when this fires, so a human reviewing the report can double-check the call.
- `docs/architecture.md` updated with the new backstop's rationale.

## Test plan
- [x] `pytest tests/test_corroborate.py -v` — 8/8 pass, including 2 new tests (positive: rationale asserting design-accepted intent gets corrected; negative: an ordinary "still a real bug" rationale that merely mentions "documentation" does NOT trigger a false-positive downgrade)
- [x] `pytest tests/` — full suite, 333/333 pass