### PR TITLE
resilience: atomic stage-output writes + surface argo resume on any stopped run

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,10 @@ manually against the instance, inside the program rules.
 
 ## 💡 Operational tips
 
+- **A run that stops (crash, Ctrl+C, a rate limit) is not lost.** Every stage writes its output
+  atomically, so `argo resume RUN_ID` continues from the first unfinished stage — no re-ingest, no
+  re-paying for stages already done. The CLI prints the exact command when a run stops. Details:
+  [cli-reference.md § Recovering a stopped run](docs/cli-reference.md#recovering-a-stopped-run).
 - Keep prompts under git and record which version each run used: you can A/B test them and see
   which produce accepted findings.
 - The SQLite ledger avoids re-reporting the same bug across runs/programs and tracks your hit rate.

--- a/argo/cli.py
+++ b/argo/cli.py
@@ -131,6 +131,28 @@ def _emit(obj: dict) -> None:
     typer.echo(json.dumps(obj, indent=2))
 
 
+def _run_with_resume_hint(fn, ctx):
+    """Run a pipeline-driving callable (``run_pipeline``/``resume_pipeline``); on ANY interruption
+    — a real failure, or the user hitting Ctrl+C — print a clear, immediate pointer to the resume
+    command before re-raising. Without this, a stopped run looks like total data loss to anyone who
+    doesn't already know ``argo resume`` exists: `status.json` and every stage's own output file
+    are written atomically and mostly survive a hard kill, but a raw Python traceback (or a silent
+    Ctrl+C) tells a normal user none of that."""
+    try:
+        return fn()
+    except (typer.Exit, SystemExit):
+        raise
+    except (KeyboardInterrupt, Exception) as exc:
+        typer.echo(
+            f"\n[argo] Run '{ctx.run_id}' stopped: {type(exc).__name__}: {exc}\n"
+            "[argo] Most progress is preserved on disk (stage outputs are written atomically).\n"
+            f"[argo] To continue from where it left off:\n"
+            f"[argo]     argo resume {ctx.run_id}\n",
+            err=True,
+        )
+        raise
+
+
 def _parse_duration(text: str) -> timedelta:
     raw = text.strip().lower()
     if raw.isdigit():
@@ -473,7 +495,7 @@ def resume(
             raise typer.BadParameter(f"resume again after {retry_after}")
         _sleep_until_retry_after(retry_after, max_wait=_parse_duration(max_wait))
     ctx = build_context(cfg, run)
-    summary = resume_pipeline(ctx)
+    summary = _run_with_resume_hint(lambda: resume_pipeline(ctx), ctx)
     _emit(summary)
 
 
@@ -747,10 +769,11 @@ def pipeline(
             return True
         return typer.confirm("Proceed into audit?", default=False)
 
-    summary = run_pipeline(ctx, brief, repo, dry_run=dry_run, research_enabled=research,
-                           links_path=links, accepted_risks_path=accepted_risks, commit=commit,
-                           estimate_before_audit=not dry_run, estimate_output=_print_estimate,
-                           estimate_confirm=_confirm_estimate)
+    summary = _run_with_resume_hint(lambda: run_pipeline(
+        ctx, brief, repo, dry_run=dry_run, research_enabled=research,
+        links_path=links, accepted_risks_path=accepted_risks, commit=commit,
+        estimate_before_audit=not dry_run, estimate_output=_print_estimate,
+        estimate_confirm=_confirm_estimate), ctx)
     summary["smoke"] = smoke
     _emit(summary)
 

--- a/argo/context.py
+++ b/argo/context.py
@@ -5,10 +5,11 @@ missing or the session died mid-write)."""
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from .config import PipelineConfig
 from .ledger import Ledger
@@ -16,6 +17,36 @@ from .models import Scope
 from .rendering import extract_manifest
 from .runner import ClaudeRunner, LLMResult
 from .schemas import validate_scope
+
+
+def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
+    """Write JSON to ``path`` atomically (temp file + ``os.replace``), so a hard kill mid-write
+    (Ctrl+C, OOM, process kill) can never leave a truncated/corrupt file behind for the NEXT stage
+    — or a resumed run — to choke on. This matters most for files re-read and rewritten by several
+    stages in turn (``validated_findings.json`` is read/rewritten by validate, corroborate,
+    deep_verify, freshness, runtime, and live) — a torn write there breaks every stage after it,
+    turning an otherwise-recoverable crash into one ``argo resume`` cannot recover from.
+
+    Retries briefly on Windows ``PermissionError`` (a concurrent reader can transiently hold the
+    file open — the same condition :func:`progress.ProgressReporter._write` works around) but,
+    unlike that telemetry writer, ultimately RAISES on persistent failure rather than dropping the
+    write silently: telemetry can afford to lose an update, a stage's real output cannot.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    text = json.dumps(data, indent=indent)
+    last_exc: OSError | None = None
+    for attempt in range(5):
+        try:
+            tmp.write_text(text, encoding="utf-8")
+            tmp.replace(path)
+            return
+        except PermissionError as exc:
+            last_exc = exc
+            time.sleep(0.02)
+    assert last_exc is not None
+    raise last_exc
 
 
 class BudgetExceeded(RuntimeError):

--- a/argo/stages/audit.py
+++ b/argo/stages/audit.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
-from ..context import BudgetExceeded, RunContext, collect_output_files
+from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
 from ..guardrails import assert_prohibited_present
 from ..rendering import with_artifact_contract
 from ..runner import RunnerError
@@ -225,8 +225,7 @@ def _audit_one(ctx: RunContext, scope, prompt_path: Path) -> tuple[str, Path | N
         return slug, None, f"findings still invalid after normalization: {exc}"
 
     out = ctx.findings_dir / f"{slug}.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(out, doc)
     _collect_variant_log(ctx, slug, work)
     n = len(doc.get("findings", []))
     _log(f"{slug}: {n} finding(s){' [partial session]' if partial else ''}")
@@ -344,7 +343,7 @@ def _run_critic_for_focus(ctx: RunContext, scope, slug: str, doc_path: Path,
              f"({len(findings)} total)")
     if len(findings) != len(doc.get("findings", [])):
         doc["findings"] = findings
-        doc_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+        atomic_write_json(doc_path, doc)
 
 
 def run(ctx: RunContext) -> list[Path]:

--- a/argo/stages/corroborate.py
+++ b/argo/stages/corroborate.py
@@ -32,7 +32,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from ..config import RESEARCH_TOOLS
-from ..context import BudgetExceeded, RunContext, collect_output_files
+from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
 from ..models import Corroboration, Finding
 from ..rendering import design_context_block, fill_placeholders, with_artifact_contract
 from ..runner import RunnerError
@@ -341,7 +341,7 @@ def run(ctx: RunContext) -> Path:
     stats["unknown_due_to_infra_failure"] = infra_failure_unknown
     stats["unknown_genuine"] = counts["unknown"] - infra_failure_unknown
     stats["verdict_self_corrected"] = overridden
-    ctx.validated_findings_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(ctx.validated_findings_path, doc)
     unknown_breakdown = (
         f"{counts['unknown']} unknown ({infra_failure_unknown} due to session/backend failure — "
         f"re-run `argo corroborate {ctx.run_id}` once the limit resets; "

--- a/argo/stages/deep_verify.py
+++ b/argo/stages/deep_verify.py
@@ -31,7 +31,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
-from ..context import BudgetExceeded, RunContext, collect_output_files
+from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
 from ..guardrails import assert_prohibited_present
 from ..models import Finding, Verification
 from ..ranking import dedup_key, split_ref
@@ -290,7 +290,7 @@ def run(ctx: RunContext) -> Path:
     stats["survivors"] = len(kept)
     stats["deep_verify_inconclusive_due_to_infra_failure"] = infra_failure
     stats["deep_verify_inconclusive_genuine"] = counts.get("inconclusive", 0) - infra_failure
-    ctx.validated_findings_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(ctx.validated_findings_path, doc)
 
     _log(f"{counts.get('reconfirmed', 0)} reconfirmed, {counts.get('corrected', 0)} corrected, "
         f"{len(split_originals)} split ({split_children_total} new finding(s)), "

--- a/argo/stages/freshness.py
+++ b/argo/stages/freshness.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Sequence
 
-from ..context import RunContext
+from ..context import RunContext, atomic_write_json
 from ..models import Finding, FreshnessCommit, FreshnessFlag
 from ..ranking import split_ref
 
@@ -336,6 +336,6 @@ def run(ctx: RunContext) -> Path:
         return ctx.validated_findings_path
 
     doc["findings"] = [f.model_dump(exclude_none=True) for f in survivors]
-    ctx.validated_findings_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(ctx.validated_findings_path, doc)
     _log(f"flagged {flagged_findings} finding(s); verdicts unchanged")
     return ctx.validated_findings_path

--- a/argo/stages/ingest.py
+++ b/argo/stages/ingest.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from ..config import ARTIFACT_TOOLS, write_pipeline_config
-from ..context import RunContext, collect_output_files
+from ..context import RunContext, atomic_write_json, collect_output_files
 from ..models import AssetVersion, RunMeta, Scope
 from ..rendering import sha256_text, with_artifact_contract
 from ..schemas import validate_scope
@@ -365,7 +365,7 @@ def run(ctx: RunContext, *, brief_path: Path | None, repo: str, repo_is_url: boo
     if not scope.prohibited_techniques:            # guardrail precondition for every render
         raise RuntimeError("ingest: scope.prohibited_techniques is empty after extraction")
 
-    ctx.scope_path.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+    atomic_write_json(ctx.scope_path, raw)
     ctx.scope = scope
 
     # --- acquire repo read-only ------------------------------------------------------

--- a/argo/stages/live.py
+++ b/argo/stages/live.py
@@ -27,7 +27,7 @@ import urllib.parse
 import urllib.request
 
 from ..config import ARTIFACT_TOOLS
-from ..context import RunContext, collect_output_files
+from ..context import RunContext, atomic_write_json, collect_output_files
 from ..guardrails import (assert_inscope_only, assert_live_authorized, assert_live_write_policy,
                           validate_probe_plan, assert_prohibited_present,
                           inscope_matchers, host_in_scope, host_of)
@@ -263,7 +263,7 @@ def _generate_plan(ctx: RunContext, scope) -> list | None:
         _log(f"generated live probe plan is not valid JSON ({exc}); skipping")
         return None
     if isinstance(plan, list) and plan:
-        (ctx.run_dir / "live_probe_plan.json").write_text(json.dumps(plan, indent=2), encoding="utf-8")
+        atomic_write_json(ctx.run_dir / "live_probe_plan.json", plan)
         _log(f"LLM generated a live probe plan for {len(plan)} finding(s)")
         return plan
     _log("LLM proposed no in-scope probeable findings")
@@ -339,7 +339,7 @@ def _attach_to_findings(ctx: RunContext, results: dict, verdicts: dict) -> None:
             verdict, evidence = ("live_confirmed" if any_met else "live_inconclusive"), None
         finding.setdefault("validation", {})["live"] = {
             "verdict": verdict, "evidence": evidence, "probes": ev.get("requests", [])}
-    vf.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(vf, doc)
 
 
 def run(ctx: RunContext):
@@ -389,7 +389,7 @@ def run(ctx: RunContext):
     (ctx.run_dir / "live_audit_log.jsonl").write_text(
         "\n".join(json.dumps(a) for a in audit) + ("\n" if audit else ""), encoding="utf-8")
     out = ctx.run_dir / "live_results.json"
-    out.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    atomic_write_json(out, results)
     _attach_to_findings(ctx, results, verdicts)
     confirmed = sum(1 for v in verdicts.values() if v.get("live_verdict") == "live_confirmed") \
         if verdicts else sum(1 for f in results["findings"]

--- a/argo/stages/recon.py
+++ b/argo/stages/recon.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from ..archetype import canonicalize
 from ..config import ARTIFACT_TOOLS
-from ..context import RunContext, collect_output_files
+from ..context import RunContext, atomic_write_json, collect_output_files
 from ..guardrails import (
     assert_audit_prompt_wellformed,
     assert_prohibited_present,
@@ -267,6 +267,6 @@ def _capture_archetype(ctx: RunContext) -> None:
     try:
         meta = json.loads(ctx.meta_path.read_text(encoding="utf-8-sig"))
         meta["archetype"] = archetype
-        ctx.meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        atomic_write_json(ctx.meta_path, meta)
     except (OSError, ValueError):
         pass  # telemetry only — never fail the run over it

--- a/argo/stages/runtime.py
+++ b/argo/stages/runtime.py
@@ -25,7 +25,7 @@ import tempfile
 from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
-from ..context import RunContext, collect_output_files
+from ..context import RunContext, atomic_write_json, collect_output_files
 from ..guardrails import (assert_loopback_only, validate_probe_plan, RuntimeProbeError,
                           assert_prohibited_present)
 from ..rendering import fill_placeholders, with_artifact_contract
@@ -302,7 +302,7 @@ def _generate_plan(ctx: RunContext, scope) -> list | None:
         _log(f"generated probe plan is not valid JSON ({exc}); skipping")
         return None
     if isinstance(plan, list) and plan:
-        (ctx.run_dir / "runtime_probe_plan.json").write_text(json.dumps(plan, indent=2), encoding="utf-8")
+        atomic_write_json(ctx.run_dir / "runtime_probe_plan.json", plan)
         _log(f"LLM generated a probe plan for {len(plan)} finding(s)")
         return plan
     _log("LLM proposed no probeable findings")
@@ -399,7 +399,7 @@ def run(ctx: RunContext) -> Path | None:
         results["verdicts"] = list(verdicts.values())
 
     out = ctx.run_dir / "runtime_results.json"
-    out.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    atomic_write_json(out, results)
     _attach_to_findings(ctx, results, verdicts)
     confirmed = sum(1 for v in verdicts.values() if v.get("runtime_verdict") == "runtime_confirmed") \
         if verdicts else sum(1 for f in results.get("findings", [])
@@ -433,4 +433,4 @@ def _attach_to_findings(ctx: RunContext, results: dict, verdicts: dict) -> None:
             "booted": results.get("booted"), "verdict": verdict,
             "evidence": evidence, "probes": ev.get("requests", []),
         }
-    vf.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(vf, doc)

--- a/argo/stages/sca.py
+++ b/argo/stages/sca.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
-from ..context import BudgetExceeded, RunContext, collect_output_files
+from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
 from ..guardrails import assert_prohibited_present
 from ..rendering import fill_placeholders, with_artifact_contract
 from ..runner import RunnerError
@@ -294,9 +294,8 @@ def run(ctx: RunContext) -> Path | None:
         return None
     doc = {"program_name": scope.program_name, "audit_focus": "dependencies",
            "generated_at": ctx.timestamp(), "findings": merged}
-    ctx.findings_dir.mkdir(parents=True, exist_ok=True)
     out = ctx.findings_dir / "dependencies.json"
-    out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    atomic_write_json(out, doc)
     _log(f"{len(merged)} dependency finding(s) ({len(det)} deterministic + "
          f"{len(merged) - len(det)} model) -> {out.name}")
     return out

--- a/argo/stages/second_opinion.py
+++ b/argo/stages/second_opinion.py
@@ -45,7 +45,7 @@ import sys
 from pathlib import Path
 
 from ..config import PipelineConfig
-from ..context import RunContext
+from ..context import RunContext, atomic_write_json
 from ..runner import build_runner
 from . import audit, ingest, recon
 
@@ -113,7 +113,7 @@ def _merge_findings_back(ctx: RunContext, sub_ctx: RunContext, pass_label: str) 
         doc["audit_focus"] = f"{pass_label}-{doc.get('audit_focus', path.stem)}"
         count += len(doc.get("findings", []))
         out_path = ctx.findings_dir / f"{pass_label}-{path.name}"
-        out_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+        atomic_write_json(out_path, doc)
     return count
 
 

--- a/argo/stages/validate.py
+++ b/argo/stages/validate.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
-from ..context import BudgetExceeded, RunContext, collect_output_files
+from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
 from ..grounding import build_index, ground_finding
 from ..guardrails import assert_prohibited_present, out_of_scope_match
 from ..models import Finding, Grounding, Validation
@@ -598,7 +598,7 @@ def run(ctx: RunContext) -> Path:
         "findings": [f.model_dump(exclude_none=True) for f in survivors],
         "dropped": dropped,
     }
-    ctx.validated_findings_path.write_text(json.dumps(out_doc, indent=2), encoding="utf-8")
+    atomic_write_json(ctx.validated_findings_path, out_doc)
     survivor_note = (
         f"{len(survivors)} survivor(s) ({infra_unvalidated} not actually adversarially validated — "
         f"session/backend failure or budget reached; re-run validate later if desired)"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,6 +29,7 @@ Everywhere below, `argo` ≡ `python -m argo.cli`.
 | `report` | 5 | `REPORT.md` + DRAFT submissions |
 | `pr-draft` | post-report | maintainer-facing GitHub PR body scaffold for one confirmed finding; local artifact only, never submits |
 | `pipeline` | 1–5 | the whole chain; **stops before any submission** |
+| `resume` | any | continue a `pipeline`/`run` invocation that stopped partway (crash, Ctrl+C, a backend rate limit, a session timeout) from wherever it left off — no re-ingest, no re-paying for already-completed stages. See "Recovering a stopped run" below |
 | `fix` | 6 (opt-in) | propose + **verify** a patch per confirmed finding (applies? compiles? no new errors?); never touches the target |
 | `bench` | 7 | score a labeled suite — findings precision/recall/F1 by archetype + CWE (+ optional A/B and patch quality) |
 | `serve` | — | run the HTTP API + web UI |
@@ -46,6 +47,7 @@ argo validate --run RUN_ID
 argo report   --run RUN_ID
 argo pr-draft --run RUN_ID --finding FINDING_ID [--test-command "CMD"]
 argo pipeline --repo PATH_OR_URL [--brief BRIEF.txt] [--links LINKS.txt] [--commit SHA] [--dry-run] [--smoke]
+argo resume   RUN_ID [--wait] [--max-wait 12h]
 argo fix      --run RUN_ID [--no-verify] [--re-audit] [--docker IMAGE] [--build-cmd "CMD"] [--only ID,ID]
 argo bench    --suite DIR [--fixes] [--re-audit] [--parallel-cases N] [--ab-audit-model MODEL]
 argo feedback [--program P --dedup K --accepted/--rejected [--run R] [--note ...]] | [--import FILE]
@@ -76,6 +78,35 @@ argo quality  [--program P] [--runs-dir DIR]
   never allowed into `reference_links`. See `--links` semantics in
   [the root README](../README.md#inputs-how-to-set-up-a-program).
 - `--run` — reuse an existing run id (generated automatically if omitted).
+
+## Recovering a stopped run
+
+If `pipeline` (or an individual stage command) stops partway — a backend crash, a rate limit, a
+session timeout, or you hitting Ctrl+C — you do **not** need to start over. Every stage writes its
+output atomically (temp file + rename), so a hard kill mid-write leaves the last good file intact
+rather than a truncated one, and `status.json` tracks exactly which stages already finished. When a
+run stops, the CLI prints the exact command to continue it:
+
+```
+[argo] Run 'RUN_ID' stopped: RunnerError: ...
+[argo] Most progress is preserved on disk (stage outputs are written atomically).
+[argo] To continue from where it left off:
+[argo]     argo resume RUN_ID
+```
+
+```bash
+argo resume RUN_ID              # continue from the first not-yet-done stage
+argo resume RUN_ID --wait       # if the failure carried a "retry after TIME" hint (e.g. a rate
+                                 # limit), sleep until then instead of failing immediately
+argo resume RUN_ID --wait --max-wait 2h   # cap how long --wait will sleep
+```
+
+`resume` re-reads the run's persisted `config.json`, so it uses the exact same settings the
+original invocation did — you don't repeat `--repo`/`--brief`/flags. A stage already marked `done`
+in `status.json` is never re-run (and never re-billed); only the first incomplete stage onward
+executes. The one hard boundary: a run that stopped **before ingest finished** (no usable
+`scope.json`/repo copy yet) can't be resumed — `resume` says so plainly and you start over with
+`pipeline`.
 
 ## Shared options (all commands)
 

--- a/tests/test_cli_resume_hint.py
+++ b/tests/test_cli_resume_hint.py
@@ -1,0 +1,56 @@
+"""``cli._run_with_resume_hint`` — the wrapper around ``run_pipeline``/``resume_pipeline`` that
+prints a clear pointer to ``argo resume <run_id>`` on any interruption, so a stopped run doesn't
+read as total data loss to someone who doesn't already know the resume command exists.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+from argo.cli import _run_with_resume_hint
+
+
+def _ctx(run_id="RUN-1"):
+    return SimpleNamespace(run_id=run_id)
+
+
+def test_returns_the_callable_result_on_success(capsys):
+    result = _run_with_resume_hint(lambda: {"ok": True}, _ctx())
+    assert result == {"ok": True}
+    assert "argo resume" not in capsys.readouterr().err
+
+
+def test_prints_the_resume_command_and_reraises_on_a_real_failure(capsys):
+    def _boom():
+        raise RuntimeError("codex exec: flagged for possible cybersecurity risk")
+
+    with pytest.raises(RuntimeError):
+        _run_with_resume_hint(_boom, _ctx("RUN-CRASHED"))
+    err = capsys.readouterr().err
+    assert "argo resume RUN-CRASHED" in err
+    assert "flagged for possible cybersecurity risk" in err
+
+
+def test_prints_the_resume_command_on_keyboard_interrupt_too(capsys):
+    """Ctrl+C is the single most likely way a normal user's run gets interrupted -- it must get
+    the same hint as a genuine exception, not vanish silently."""
+    def _ctrl_c():
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        _run_with_resume_hint(_ctrl_c, _ctx("RUN-2"))
+    assert "argo resume RUN-2" in capsys.readouterr().err
+
+
+def test_does_not_print_the_hint_for_a_clean_typer_exit(capsys):
+    """typer.Exit / SystemExit are the CLI's own normal control-flow signals (e.g. from an earlier
+    typer.BadParameter), not a pipeline failure -- must pass through silently."""
+    def _clean_exit():
+        raise typer.Exit(code=1)
+
+    with pytest.raises(typer.Exit):
+        _run_with_resume_hint(_clean_exit, _ctx("RUN-3"))
+    assert "argo resume" not in capsys.readouterr().err

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,75 @@
+"""``context.atomic_write_json`` — the temp-file + os.replace helper stage outputs use so a hard
+kill mid-write can never leave a torn/corrupt file behind for the next stage or a resumed run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from argo.context import atomic_write_json
+
+
+def test_writes_correct_content_and_leaves_no_tmp_file(tmp_path):
+    path = tmp_path / "validated_findings.json"
+    atomic_write_json(path, {"findings": [{"id": "F-1"}]})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"findings": [{"id": "F-1"}]}
+    assert not path.with_suffix(".json.tmp").exists()
+
+
+def test_creates_missing_parent_directories(tmp_path):
+    path = tmp_path / "nested" / "dir" / "out.json"
+    atomic_write_json(path, {"ok": True})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"ok": True}
+
+
+def test_a_write_that_fails_before_replace_never_touches_the_original(tmp_path, monkeypatch):
+    """The core guarantee: if the process dies (or errors) after writing the temp file but before
+    the atomic replace, the file a resumed run would read is still the LAST GOOD version — never a
+    half-written one. Simulated by making ``Path.replace`` raise partway through."""
+    path = tmp_path / "validated_findings.json"
+    atomic_write_json(path, {"version": 1})  # a real "last good" file already on disk
+
+    def _boom(self, target):
+        raise OSError("simulated kill mid-replace")
+
+    monkeypatch.setattr(Path, "replace", _boom, raising=True)
+    with pytest.raises(OSError):
+        atomic_write_json(path, {"version": 2})
+
+    # the original, valid file is untouched -- a resumed run reads version 1, not a torn file
+    assert json.loads(path.read_text(encoding="utf-8")) == {"version": 1}
+
+
+def test_retries_transient_windows_permission_error_then_succeeds(tmp_path, monkeypatch):
+    path = tmp_path / "out.json"
+    attempts = {"n": 0}
+    real_replace = Path.replace
+
+    def _flaky_replace(self, target):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise PermissionError("WinError 5: simulated concurrent reader")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _flaky_replace, raising=True)
+    monkeypatch.setattr("argo.context.time.sleep", lambda _: None)  # don't actually sleep in tests
+    atomic_write_json(path, {"ok": True})
+    assert attempts["n"] == 3
+    assert json.loads(path.read_text(encoding="utf-8")) == {"ok": True}
+
+
+def test_raises_after_persistent_permission_error_instead_of_silently_dropping(tmp_path, monkeypatch):
+    """Unlike progress.py's telemetry writer (which may drop an update rather than crash the run),
+    a stage's real output must never be silently lost -- persistent failure must raise."""
+    path = tmp_path / "out.json"
+
+    def _always_locked(self, target):
+        raise PermissionError("WinError 5: still locked")
+
+    monkeypatch.setattr(Path, "replace", _always_locked, raising=True)
+    monkeypatch.setattr("argo.context.time.sleep", lambda _: None)
+    with pytest.raises(PermissionError):
+        atomic_write_json(path, {"ok": True})


### PR DESCRIPTION
## Summary
Two reliability gaps found while diagnosing why a stopped run can look like total data loss to a user not babysitting it:

- **Atomic stage-output writes.** Every stage wrote its own output JSON (`validated_findings.json`, `findings/*.json`, `scope.json`, `meta.json`, ...) with a plain `write_text`, not the atomic temp-file+replace pattern `progress.py` already used for `status.json`. `validated_findings.json` in particular is read/rewritten by six different stages in turn — a hard kill mid-write there could truncate the one file a resume needs to read. Added `context.atomic_write_json` and switched every stage's production output write to it.
- **`argo resume` surfaced and documented.** It exists and mostly works, but was undocumented (not in README or `cli-reference.md`) and neither `pipeline` nor `resume` printed anything pointing to it when a run stopped — just a raw traceback. Added `cli._run_with_resume_hint`: on any interruption (real failure or Ctrl+C) it prints the exact `argo resume <run_id>` command before re-raising. Documented the command and a new "Recovering a stopped run" section in `cli-reference.md`, plus a pointer from README's Operational tips.

## Test plan
- [x] `pytest tests/test_context.py tests/test_cli_resume_hint.py -v` — 9/9 new tests pass (atomic-write correctness/durability/retry semantics; resume-hint success/failure/Ctrl+C/clean-exit paths)
- [x] `pytest tests/` — full suite, 342/342 pass