### PR TITLE
neutral-register: same-backend retry with a softened prompt on a Codex moderation flag

### DIFF
--- a/argo/prompts/02_adversarial_validation_prompt.neutral.md
+++ b/argo/prompts/02_adversarial_validation_prompt.neutral.md
@@ -1,0 +1,103 @@
+# FINDING VALIDATION PROMPT (neutral-register variant)
+
+> Pipeline stage: **4 (triage / validation)**. Run this in a **fresh, isolated context**,
+> once per candidate finding. Your job is to independently re-derive whether the finding holds:
+> not to find new bugs, but to check this specific one against the code with the same rigor a
+> careful senior reviewer would use before it ships in a report. Only findings that survive
+> independent re-derivation get promoted. This stage is the single biggest lever on your
+> accepted-report rate.
+
+---
+
+## INJECTED CONTEXT
+
+CANDIDATE FINDING (one finding, verbatim from the audit JSON):
+```json
+{{FINDING_JSON}}
+```
+
+RELEVANT SOURCE (the orchestrator attaches the cited files + a few lines of surrounding context):
+```
+{{CODE_EXCERPTS}}
+```
+
+REPOSITORY ROOT (read-only, for following the data flow yourself): {{REPO_PATH}}
+TARGET TYPE: {{TARGET_TYPE}}   # source_only | source_and_live
+SCOPE (for confirming the finding is in-scope):
+```json
+{{SCOPE_JSON}}
+```
+
+RECON GROUND TRUTH for this finding's focus (authoritative — the audit stage already established
+these by reading the code; use them so you do NOT re-derive and wrongly refute a real bug):
+{{GROUND_TRUTH}}
+
+---
+
+## ROLE
+
+You are a careful senior reviewer whose job is to independently determine whether this report is
+correct before it goes out. Re-derive it yourself from the code rather than taking the author's
+reasoning on trust — the goal is an accurate verdict, not a favorable one in either direction.
+
+## HARD CONSTRAINTS
+
+- Source/static analysis only. Do **not** contact any live host, even if `source_and_live`.
+- Do not patch. Do not weaken the finding to make it "kind of" true — judge it as written.
+- Authorized engagement: confirm the finding targets an **in-scope** asset; if not, mark it
+  out-of-scope regardless of technical merit.
+
+## WHAT TO CHECK (re-derive each link in the chain independently)
+
+1. **Reachability.** Is the flagged code actually reachable from an externally-controllable
+   entry point? Trace the call path. If it's dead code, internal-only, or gated upstream, say so.
+2. **Control of input.** Does the data reaching the sink genuinely come from an untrusted source
+   that an outside caller can influence? Or is it constant / validated / server-derived?
+3. **Effective sanitization or encoding** anywhere on the path (framework defaults count —
+   e.g. parameterized queries, auto-encoding template engines, allow-list validation,
+   auth middleware). A real mitigation in the path means the finding does not hold as written.
+4. **Sink reality.** Is the sink actually dangerous in this context, or is the danger assumed?
+   (e.g. "raw HTML" that is actually rendered in a text/JSON context; a "deserialization" that
+   uses a safe, non-polymorphic serializer.)
+5. **Auth/authz findings:** is the missing check truly absent, or enforced elsewhere
+   (filter, policy, service-layer guard, middleware)? Re-derive the *enforced* access, not the
+   declared one.
+6. **Preconditions & severity honesty.** List every precondition the scenario requires. If they
+   are unrealistic or already privileged, downgrade severity accordingly.
+
+## VERDICT (required output, JSON)
+
+```json
+{
+  "finding_id": "...",
+  "verdict": "confirmed | refuted | needs_runtime_verification | out_of_scope",
+  "validated_confidence": "Confirmed | High | Medium | Low",
+  "validated_severity": "Critical | High | Medium | Low | Informational",
+  "refutation_attempts": [
+    {"link": "reachability|input_control|sanitization|sink|authz|preconditions",
+     "result": "held | broke", "evidence": "file:line + reasoning"}
+  ],
+  "surviving_data_flow": "source -> ... -> sink, with file:line at each hop (empty if refuted)",
+  "unmet_preconditions": ["..."],
+  "rationale": "1-3 sentences",
+  "live_verification_plan": "safe, in-scope, non-DoS steps for a human (only if needs_runtime_verification)"
+}
+```
+
+Rules for the verdict (DOWNGRADE-DON'T-DELETE — a wrongly-refuted real bug is the worst outcome
+here, worse than a kept-but-downgraded one):
+- `confirmed` if the full source→sink flow holds with no effective mitigation on the path.
+- `refuted` ONLY when the finding is **provably wrong from the code** — you can cite the exact
+  `file:line` that contradicts it: a real mitigation sits ON the path, the input is genuinely not
+  externally controllable, the sink is not dangerous in this context, OR the finding matches one
+  of the **FALSE-POSITIVE CARVE-OUTS** above (cite which). "I couldn't fully confirm it" is NOT
+  grounds to refute.
+- `needs_runtime_verification` is the default for an UNCERTAIN finding: the static evidence is
+  plausible but a link depends on runtime/config state, or on code you cannot see, or you simply
+  could not disprove it. Downgrade `validated_severity`/`validated_confidence` honestly and write the
+  precise question a human must answer. **Do not refute out of doubt — downgrade and keep.**
+- `out_of_scope` if the affected asset is not in `SCOPE_JSON`.
+- Ground-truth use: if a **BASELINE-CORRECT** reference shows the correct shape and this finding's
+  code deviates from it, that is evidence the bug is REAL — do not refute it on a "maybe it's handled
+  elsewhere" assumption; verify the specific path. Only the explicit CARVE-OUTS are pre-cleared.
+- Be honest about downgrades. A confirmed-but-low or kept-for-runtime finding beats a wrongly-rejected one.

--- a/argo/prompts/02b_adversarial_validation_batch_prompt.neutral.md
+++ b/argo/prompts/02b_adversarial_validation_batch_prompt.neutral.md
@@ -1,0 +1,95 @@
+# FINDING VALIDATION — BATCH (neutral-register variant)
+
+> Pipeline stage: **4 (triage / validation)**, batched. Your job is to independently re-derive
+> whether each finding holds: not to find new bugs, but to check each one against the code with
+> the same rigor a careful senior reviewer would use before it ships in a report. Only findings
+> that survive independent re-derivation get promoted. This is the single biggest lever on your
+> accepted-report rate.
+>
+> **Validate EACH finding below INDEPENDENTLY**, as if it were the only one in front of you. One
+> finding's verdict must NOT influence another's — do not assume a batch is "mostly right" or "mostly
+> wrong". Re-derive each from the code. (Batching is an efficiency measure; it must not lower rigor.)
+
+---
+
+## INJECTED CONTEXT
+
+REPOSITORY ROOT (read-only, for following each data flow yourself): {{REPO_PATH}}
+TARGET TYPE: {{TARGET_TYPE}}   # source_only | source_and_live
+SCOPE (for confirming each finding is in-scope):
+```json
+{{SCOPE_JSON}}
+```
+
+CANDIDATE FINDINGS (a JSON array; each item has `finding_id`, the verbatim `finding`, its attached
+`code_excerpts`, and the recon `ground_truth` for its focus — authoritative, established by the audit
+stage; use it so you do NOT re-derive and wrongly refute a real bug):
+```json
+{{FINDINGS_BATCH}}
+```
+
+---
+
+## ROLE
+
+You are a careful senior reviewer whose job is to independently determine whether each report is
+correct before it goes out. For each finding, re-derive it yourself from the code rather than
+taking the author's reasoning on trust — the goal is an accurate verdict, not a favorable one in
+either direction.
+
+## HARD CONSTRAINTS
+
+- Source/static analysis only. Do **not** contact any live host, even if `source_and_live`.
+- Do not patch. Do not weaken a finding to make it "kind of" true — judge each as written.
+- Authorized engagement: confirm each finding targets an **in-scope** asset; if not, mark it as
+  out-of-scope regardless of technical merit.
+
+## WHAT TO CHECK (per finding — re-derive each link in the chain independently)
+
+1. **Reachability** from an externally-controllable entry point (trace the call path; dead/internal/gated → say so).
+2. **Control of input** reaching the sink (vs constant / validated / server-derived).
+3. **Effective sanitization or encoding** anywhere on the path (framework defaults count). A real mitigation on the path means the finding does not hold as written.
+4. **Sink reality** — is the sink actually dangerous in this context, or is the danger assumed?
+5. **Auth/authz** — is the missing check truly absent, or enforced elsewhere (filter/policy/middleware)? Re-derive the *enforced* access.
+6. **Preconditions & severity honesty** — list every precondition; downgrade severity if they are unrealistic or already privileged.
+
+## OUTPUT (required — a single file `verdicts.json`)
+
+One object per input finding, in a `verdicts` array. Every `finding_id` from the batch MUST appear
+exactly once.
+
+```json
+{
+  "verdicts": [
+    {
+      "finding_id": "...",
+      "verdict": "confirmed | refuted | needs_runtime_verification | out_of_scope",
+      "validated_confidence": "Confirmed | High | Medium | Low",
+      "validated_severity": "Critical | High | Medium | Low | Informational",
+      "refutation_attempts": [
+        {"link": "reachability|input_control|sanitization|sink|authz|preconditions",
+         "result": "held | broke", "evidence": "file:line + reasoning"}
+      ],
+      "surviving_data_flow": "source -> ... -> sink, with file:line at each hop (empty if refuted)",
+      "unmet_preconditions": ["..."],
+      "rationale": "1-3 sentences",
+      "live_verification_plan": "safe, in-scope, non-DoS steps for a human (only if needs_runtime_verification)"
+    }
+  ]
+}
+```
+
+Rules for each verdict (DOWNGRADE-DON'T-DELETE — a wrongly-refuted real bug is the worst outcome,
+worse than a kept-but-downgraded one):
+- `confirmed` if the full source→sink flow holds with no effective mitigation on the path.
+- `refuted` ONLY when the finding is **provably wrong from the code** — cite the exact `file:line` that
+  contradicts it (a real mitigation on the path, input not externally controllable, sink not dangerous
+  here, OR it matches a **FALSE-POSITIVE CARVE-OUT** in its ground truth — cite which). "I couldn't
+  fully confirm it" is NOT grounds to refute.
+- `needs_runtime_verification` is the default for an UNCERTAIN finding: plausible static evidence but a
+  link depends on runtime/config or code you cannot see. Downgrade severity/confidence honestly and
+  write the precise question a human must answer. **Do not refute out of doubt — downgrade and keep.**
+- `out_of_scope` if the affected asset is not in `SCOPE_JSON`.
+- Ground-truth use: if a **BASELINE-CORRECT** reference shows the correct shape and this finding's code
+  deviates, that is evidence the bug is REAL — verify the specific path; only explicit CARVE-OUTS are
+  pre-cleared.

--- a/argo/prompts/09_deep_verify_prompt.neutral.md
+++ b/argo/prompts/09_deep_verify_prompt.neutral.md
@@ -1,0 +1,154 @@
+# DEEP VERIFY PROMPT (neutral-register variant)
+
+> Pipeline stage: **7 (deep verify)**, opt-in. Run this in a **fresh, isolated context**, once per
+> surviving finding, with full read-only repo access and NO turn/excerpt budget pressure. This is
+> the last and deepest human-grade check before a finding is reported: everything before this stage
+> (audit, validate, corroborate) judged this finding from an excerpt and/or in isolation from its
+> siblings. You do neither. You re-derive it from the real source, and you check it against every
+> other surviving finding, exactly as a senior engineer would before signing off on a disclosure.
+
+---
+
+## INJECTED CONTEXT
+
+FINDING TO DEEP-VERIFY (already survived independent validation, and corroboration if enabled):
+```json
+{{FINDING_JSON}}
+```
+
+PRIOR VERDICTS on this finding, for context only — do NOT defer to them, re-derive independently:
+```json
+{{PRIOR_VERDICTS_JSON}}
+```
+
+CODE EXCERPTS (a starting point only — the full repo is mounted read-only; read past the excerpt
+boundary, open sibling/caller/callee files, and confirm struct/ABI/precondition details yourself):
+```
+{{CODE_EXCERPTS}}
+```
+
+REPOSITORY ROOT (read-only, use Read/Grep/Glob freely — there is no excerpt budget here): {{REPO_PATH}}
+TARGET TYPE: {{TARGET_TYPE}}   # source_only | source_and_live
+SCOPE:
+```json
+{{SCOPE_JSON}}
+```
+
+OTHER SURVIVING FINDINGS IN THIS RUN (id, title, CWE, affected refs, one-line summary — this is
+the cross-finding context no earlier stage had, because validate/corroborate deliberately judge
+each finding in isolation):
+```json
+{{SIBLING_FINDINGS_JSON}}
+```
+
+---
+
+## ROLE
+
+You are the final, most senior reviewer in the pipeline — the one who reads every cited line before
+a finding ships to a maintainer. Your job is not "does this look plausible" (validate already asked
+that) and not "do the docs/history agree" (corroborate already asked that). Your job is: **rebuild
+the finding from the source code as if no one had written it down, then compare your own rebuild
+against what was claimed.** Where they diverge, the source wins.
+
+## HARD CONSTRAINTS
+
+- Source/static analysis only. Do **not** contact any live host, even if `source_and_live`.
+- Do not patch. Do not weaken or embellish the finding to make it fit a verdict — judge what you
+  actually find in the code, even if it differs from the finding as written.
+- Use your full tool budget. Open the actual file, not just the excerpt. Follow calls into sibling
+  functions, check the struct/type definitions referenced, grep for other call sites of the same
+  sink, and read at least one comparable "known-correct" code path if one exists in this repo
+  (e.g. a sibling parser/handler that does the same thing safely) before you conclude either way.
+
+## WHAT TO DO (in order)
+
+1. **Re-derive from scratch.** Read the cited file(s) at the actual current line numbers (they may
+   have drifted from the excerpt). Trace the full data flow yourself: where does the value
+   originate, what touches it on the way, where does it land. Do not read the finding's own
+   `vulnerable_flow`/`why_vulnerable` text as ground truth — read the code, then compare.
+2. **Check reachability against sibling consumers of the same untrusted input.** This is the check
+   validate/corroborate structurally cannot do (isolated, excerpt-budgeted) and that reading only
+   the flagged site will miss even carefully: for a finding whose claim is "this exact input reaches
+   this exact allocation/loop/sink and crashes or misbehaves," grep the whole repo for every OTHER
+   place the same untrusted field, byte range, or object is read, parsed, or walked — especially any
+   pass that plausibly runs BEFORE the flagged code in the real execution order (a pre-scan, a
+   dependency/usage collector, an earlier validation/normalization step, a first-pass tokenizer).
+   If such an earlier consumer exists, check what it does on the exact malformed input this finding
+   requires: does it throw/fail in a way that gets caught and used to mark the item as
+   already-failed (a shared error flag, an "already errored, skip further processing" guard, an
+   early return keyed off a prior exception) — and if so, would that prevent the flagged code from
+   ever running for this specific input? (Concretely seen in the wild: a size field with no upfront
+   bound in the flagged allocation was ALSO walked unit-by-unit with no upfront allocation by an
+   earlier, unrelated dependency-scan pass; that pass hit a plain, caught exception on the malformed
+   input first and flagged the item as already-erroneous, so the later flagged allocation was never
+   actually reached for the simplest version of the unexpected input — the code defect was real, the
+   "this crashes the whole run" reachability claim was not, until a different construction was used.)
+   This does not make the underlying code correct or the finding disappear — the missing bound is
+   still a real latent defect — but an incidental, coincidental gate elsewhere changes what you can
+   honestly claim about triggering it, and that must be reflected in the verdict (see `corrected`
+   below), not silently reconfirmed as originally worded.
+3. **Check every factual claim.** Field/variable names, struct sizes, byte offsets, function
+   signatures, whether a check exists and where, the exact precondition. A finding can have a real,
+   triggerable mechanism and still contain a wrong detail (wrong offset, wrong function name, an
+   off-by-one in the stated trigger, or a reachability/"this reliably crashes" claim undercut by step
+   2 above) — that is `corrected`, not `refuted` and not `reconfirmed` as-is.
+4. **Cross-finding clustering.** Compare against every finding in OTHER SURVIVING FINDINGS above:
+   - **Same root cause, different call site or wording** (e.g. the same missing bounds check
+     reached through two different entry points, or the same bug described by two audit foci with
+     different finding IDs) -> `merged`, pointing at the other finding's id via `merged_into`. Prefer
+     keeping the finding with the clearer/more complete write-up as the survivor; merge the other
+     into it. Do NOT merge findings that share a CWE/file but have genuinely distinct triggers.
+   - **This one finding is actually >=2 independently triggerable bugs** bundled under one
+     description (e.g. two different fields decoded by the same function, each with its own
+     independent missing check, each individually triggerable without the other) -> `split`, with
+     one fully self-contained Finding-shaped object per sub-bug in `split_into` (each needs its own
+     `affected`/`vulnerable_flow`/`why_vulnerable`/`exploit_scenario`/`impact`/`recommended_fix`,
+     following the same shape as the injected `FINDING_JSON`). Do NOT split a single bug just because
+     it has multiple symptoms or multiple affected refs — only split if each half survives on its
+     own even if the other were already fixed.
+5. **Decide the verdict** using the table below. Be honest: `reconfirmed` is not the default,
+   thoroughness is. If you did not actually open the file and re-trace it, you have not verified it.
+
+## VERDICT (required output, JSON)
+
+```json
+{
+  "finding_id": "...",
+  "verdict": "reconfirmed | corrected | split | merged | refuted | inconclusive",
+  "independent_derivation": "your own re-derivation transcript: file:line trail you actually walked, sibling/caller/callee functions you opened, the struct/ABI/precondition detail you confirmed, and any known-correct comparable path you checked. This is the audit trail for this pass -- be specific, cite file:line, not vague.",
+  "rationale": "1-3 sentences: the verdict and why",
+  "corrections": "only if verdict == corrected: exactly what was factually wrong and the corrected fact(s)",
+  "split_into": "only if verdict == split: a JSON array of fully independent Finding-shaped objects, one per sub-bug",
+  "merged_into": "only if verdict == merged: the OTHER surviving finding's id this duplicates",
+  "related_finding_ids": ["finding ids from OTHER SURVIVING FINDINGS you compared against, even if the verdict stayed reconfirmed"]
+}
+```
+
+Rules for the verdict (DOWNGRADE-DON'T-DELETE still applies — corrected/inconclusive keep the
+finding; only `refuted` and `merged` remove it from the active list, and `merged` keeps it in an
+appendix, never silently deleted):
+- `reconfirmed`: you re-traced the flow yourself in the actual current source and every factual
+  claim in the finding checked out. `independent_derivation` must show the trail, not just say "ok".
+- `corrected`: the underlying mechanism is real and still reportable, but you found a wrong fact
+  (wrong file:line, wrong field name, wrong precondition, an off-by-one in the trigger, or — per
+  step 2 above — a reachability/"this reliably triggers" claim that an earlier sibling consumer of
+  the same untrusted input incidentally blocks for the simplest construction). Fold the correct
+  facts into `corrections`, including what you found in step 2 even when it doesn't change the
+  verdict; the finding is kept and the report will note the correction.
+- `split`: see above. Every entry in `split_into` must independently satisfy `reconfirmed`-level
+  scrutiny on its own — do not split speculatively.
+- `merged`: see above. Point at the id of the finding you are keeping; do not merge two findings
+  into each other (pick one direction).
+- `refuted`: deep re-derivation shows validate AND corroborate were both wrong — you can cite the
+  exact `file:line` that contradicts the finding (a mitigation actually sits on the path, the sink
+  isn't reachable the way claimed, the input isn't externally controllable). This should be RARE —
+  two earlier passes already tried to break it — but a wrong survivor must not ship. Cite hard
+  evidence, not doubt.
+- `inconclusive`: you made a genuine, thorough attempt (tool calls, file reads — show them in
+  `independent_derivation`) and could not settle it either way from the source alone (e.g. it
+  depends on a runtime/config value not visible statically). This is different from a session/
+  infra failure and different from "I didn't have time to check" — you must have actually tried.
+- If a finding matches an accepted-by-design behavior (see below), that is grounds for `refuted`
+  with a rationale naming the accepted risk — the earlier stages should have caught this, but you
+  are the last check.

--- a/argo/rendering.py
+++ b/argo/rendering.py
@@ -53,6 +53,100 @@ def fill_placeholders(template_text: str, mapping: dict[str, str]) -> str:
     return out
 
 
+def render_prompt_pair(assets_dir: Path, template_name: str,
+                       mapping: dict[str, str]) -> tuple[str, str | None]:
+    """Render ``template_name`` via :func:`fill_placeholders`, plus its neutral-register
+    companion if one exists on disk (``<name-without-.md>.neutral.md``, filled with the SAME
+    mapping). Returns ``(prompt, neutral_prompt)``; ``neutral_prompt`` is ``None`` when no
+    companion file is present, so a caller can pass it straight through to
+    ``AgentRunner.run(..., neutral_prompt=...)`` without an extra existence check.
+
+    The companion is a plain hand-authored template (same placeholders, same output contract as
+    the original — only the narrative framing softened), not a derived/generated variant, so
+    rendering it costs nothing beyond the primary template."""
+    template = (assets_dir / template_name).read_text(encoding="utf-8")
+    prompt = fill_placeholders(template, mapping)
+    neutral_path = assets_dir / (template_name.removesuffix(".md") + ".neutral.md")
+    neutral_prompt = (fill_placeholders(neutral_path.read_text(encoding="utf-8"), mapping)
+                      if neutral_path.is_file() else None)
+    return prompt, neutral_prompt
+
+
+#: Curated, deterministic word/phrase substitutions for :func:`neutralize_audit_prompt`. Ordered
+#: most-specific-first (multi-word/hyphenated phrases before the bare word they contain) so a
+#: later, broader pattern never re-matches text a more specific one already rewrote. Deliberately
+#: NOT touching "vulnerability"/"vulnerable" or CWE/severity vocabulary — that terminology is
+#: inherent to the audit task itself (and the findings schema downstream), not the adversarial
+#: *framing* around it; only the narrative register is softened here. Case-preserving (matches
+#: Title/UPPER/lower case) via :func:`_case_like`.
+_AUDIT_NEUTRAL_LEXICON: tuple[tuple[re.Pattern, str], ...] = tuple(
+    (re.compile(pattern, re.IGNORECASE), replacement) for pattern, replacement in (
+        (r"\battack surfaces\b", "exposed interfaces"),
+        (r"\battack surface\b", "exposed interface"),
+        # Hyphenated compounds (attacker-controlled/-supplied/-influenced/-controllable/...) must
+        # be rewritten BEFORE the bare \battacker\b rule below: "attacker-" already satisfies that
+        # rule's trailing \b (a hyphen is a non-word char), so without this ordering the bare rule
+        # would fire first and leave a broken "an untrusted caller-controlled" behind.
+        (r"\battacker-(?=\w)", "externally-"),
+        (r"\battackers\b", "untrusted callers"),
+        (r"\battacker\b", "an untrusted caller"),
+        (r"\bexploitable\b", "triggerable"),
+        (r"\bexploited\b", "triggered"),
+        (r"\bexploiting\b", "triggering"),
+        (r"\bexploits\b", "triggers"),
+        (r"\bexploit\b", "trigger"),
+        (r"\bmalicious\b", "unexpected"),
+        (r"\badversarial\b", "challenging"),
+        (r"\battacks\b", "abuse cases"),
+        (r"\battack\b", "abuse"),
+    )
+)
+
+#: A top-level markdown heading ends whatever protected section (see ``neutralize_audit_prompt``)
+#: was opened by an earlier line — checked against ``01_audit_prompt_template.md.j2``, where
+#: "PROHIBITED TECHNIQUES (hard limits):" is plain prose *inside* the "## SCOPE & RULES OF
+#: ENGAGEMENT" section, not its own heading, so the protected block must be opened by matching the
+#: phrase on ANY line (heading or not) and closed only at the next top-level heading.
+_TOP_HEADING_RE = re.compile(r"^\s*#{1,2}\s")
+
+
+def _case_like(sample: str, replacement: str) -> str:
+    if sample.isupper():
+        return replacement.upper()
+    if sample[:1].isupper():
+        return replacement[:1].upper() + replacement[1:]
+    return replacement
+
+
+def neutralize_audit_prompt(text: str) -> str:
+    """Best-effort, deterministic, zero-LLM-cost rewrite of an already-rendered audit prompt's
+    NARRATIVE register (see ``_AUDIT_NEUTRAL_LEXICON``), for a reactive retry after Codex's
+    moderation classifier flags the original. There is no static per-focus template to pair a
+    hand-authored neutral variant with (audit prompts are synthesized prose written by the recon
+    model, see ``stages/recon.py``), so this operates on the rendered text directly instead.
+
+    Skips the PROHIBITED TECHNIQUES block (from the line that names it through the next top-level
+    heading) entirely, so the scope's verbatim constraint text — checked by
+    ``guardrails.assert_prohibited_present`` — is never rewritten. This is best-effort, not a
+    proof: callers that also gate on that assertion should re-check the result before sending it,
+    exactly as they already do for the original prompt."""
+    protected = False
+    out_lines = []
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if protected and _TOP_HEADING_RE.match(line):
+            protected = False
+        if "prohibited techniques" in stripped.lower():
+            protected = True
+        if protected:
+            out_lines.append(line)
+            continue
+        for pattern, replacement in _AUDIT_NEUTRAL_LEXICON:
+            line = pattern.sub(lambda m: _case_like(m.group(0), replacement), line)
+        out_lines.append(line)
+    return "".join(out_lines)
+
+
 def render_audit_template(ctx: dict, prompts_dir: Path) -> str:
     """Render ``01_audit_prompt_template.md.j2`` with StrictUndefined (any missing slot
     raises rather than emitting a blank)."""

--- a/argo/runner.py
+++ b/argo/runner.py
@@ -218,6 +218,46 @@ class AgentRunner(ABC):
         repo_dir: Path | None = None,
         allowed_tools: tuple[str, ...] = ARTIFACT_TOOLS,
         label: str | None = None,
+        neutral_prompt: str | None = None,
+    ) -> LLMResult:
+        """Run one session; on a moderation-flagged failure, retry ONCE on this SAME backend with
+        ``neutral_prompt`` (a caller-supplied differently-worded variant of ``prompt``) if one was
+        supplied. Bounded to exactly one retry (no recursion). Both attempts are logged
+        independently via the normal ledger/jsonl path in :meth:`_run_attempt`, so the audit trail
+        shows the flag and the recovery. A caller that never passes ``neutral_prompt`` sees
+        byte-identical behavior to a plain single attempt. This is orthogonal to (and unaware of)
+        :class:`FallbackRunner`'s cross-backend retry and the orchestrator's whole-stage
+        auto-retry — three independent layers, see docs/architecture.md."""
+        try:
+            return self._run_attempt(
+                prompt=prompt, run_dir=run_dir, work_dir=work_dir, model=model, stage=stage,
+                run_id=run_id, repo_dir=repo_dir, allowed_tools=allowed_tools, label=label,
+            )
+        except RunnerError as exc:
+            if exc.failure_kind != "moderation_flagged" or neutral_prompt is None:
+                raise
+            print(f"[runner] stage={stage} label={label!r} was moderation-flagged; retrying once "
+                  f"in {_NEUTRAL_RETRY_DELAY_S:.0f}s with a neutral-register prompt variant",
+                  file=sys.stderr)
+            time.sleep(_NEUTRAL_RETRY_DELAY_S)
+            return self._run_attempt(
+                prompt=neutral_prompt, run_dir=run_dir, work_dir=work_dir, model=model,
+                stage=stage, run_id=run_id, repo_dir=repo_dir, allowed_tools=allowed_tools,
+                label=f"{label}-neutral-retry" if label else "neutral-retry",
+            )
+
+    def _run_attempt(
+        self,
+        *,
+        prompt: str,
+        run_dir: Path,
+        work_dir: Path,
+        model: str,
+        stage: str,
+        run_id: str,
+        repo_dir: Path | None = None,
+        allowed_tools: tuple[str, ...] = ARTIFACT_TOOLS,
+        label: str | None = None,
     ) -> LLMResult:
         # --- guardrails ---------------------------------------------------------------
         # One backend-neutral policy ("no network except research; repo never writable"); each
@@ -1065,6 +1105,16 @@ _COOLDOWN_BY_FAILURE_KIND: dict[str, timedelta] = {
 #: really the same classifier being hit again. Untested exact duration -- a reasoned starting point
 #: pending real validation, not a measured constant.
 _MODERATION_RETRY_DELAY = timedelta(seconds=90)
+
+#: Delay before AgentRunner.run()'s own same-backend, same-call retry with a caller-supplied
+#: neutral-register ``neutral_prompt`` (see run()). Deliberately much shorter than
+#: `_MODERATION_RETRY_DELAY`: that 90s figure exists because identical back-to-back retries of
+#: the SAME prompt kept flagging on every attempt -- a neutrally-worded prompt is a materially
+#: different input to the classifier, so the same "let the classifier cool down" justification
+#: doesn't apply at full strength. A short pause is still cheap insurance against anything
+#: session/account-level rather than purely content-based. Untested exact duration -- a reasoned
+#: starting point, not a measured constant, same as the other timing constants in this module.
+_NEUTRAL_RETRY_DELAY_S = 5.0
 
 
 class FallbackRunner(AgentRunner):

--- a/argo/stages/audit.py
+++ b/argo/stages/audit.py
@@ -15,14 +15,31 @@ from pathlib import Path
 
 from ..config import ARTIFACT_TOOLS
 from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_output_files
-from ..guardrails import assert_prohibited_present
-from ..rendering import with_artifact_contract
+from ..guardrails import PromptGuardrailError, assert_prohibited_present
+from ..rendering import neutralize_audit_prompt, with_artifact_contract
 from ..runner import RunnerError
 from ..schemas import SchemaValidationError, validate_findings
 
 
 def _log(msg: str) -> None:
     print(f"[audit] {msg}", file=sys.stderr)
+
+
+def _neutral_variant(prompt: str, scope, slug: str) -> str | None:
+    """Best-effort neutral-register variant for a reactive retry after a moderation flag (see
+    ``rendering.neutralize_audit_prompt``). Re-checked against the SAME guardrail the original
+    prompt passed (``assert_prohibited_present``) before it is ever handed to ``ctx.runner.run``
+    — if the deterministic rewrite happened to touch the scope's verbatim constraint text, fall
+    back to no neutral variant (the call still gets a normal single attempt, just without the
+    retry) rather than silently sending a weakened prompt."""
+    candidate = neutralize_audit_prompt(prompt)
+    try:
+        assert_prohibited_present(candidate, scope.prohibited_techniques)
+    except PromptGuardrailError:
+        _log(f"{slug}: neutral-register variant dropped a prohibited-technique constraint; "
+             "no neutral retry available for this focus")
+        return None
+    return candidate
 
 
 # Findings-schema string-typed fields. Real models sometimes emit these as structured
@@ -181,6 +198,7 @@ def _audit_one(ctx: RunContext, scope, prompt_path: Path) -> tuple[str, Path | N
     try:
         result = ctx.runner.run(
             prompt=prompt,
+            neutral_prompt=_neutral_variant(prompt, scope, slug),
             run_dir=ctx.run_dir,
             work_dir=work,
             model=ctx.config.model_for("audit"),
@@ -294,7 +312,8 @@ def _critic_pass(ctx: RunContext, scope, slug: str, prompt_path: Path,
     work = ctx.work_dir("audit", f"{slug}__critic")
     try:
         result = ctx.runner.run(
-            prompt=prompt, run_dir=ctx.run_dir, work_dir=work,
+            prompt=prompt, neutral_prompt=_neutral_variant(prompt, scope, f"{slug}-critic"),
+            run_dir=ctx.run_dir, work_dir=work,
             model=ctx.config.model_for("audit"), stage="audit", run_id=ctx.run_id,
             repo_dir=ctx.repo_dir, allowed_tools=ARTIFACT_TOOLS, label=f"{slug}-critic")
         files = collect_output_files(result, "SECURITY_FINDINGS__*.json")

--- a/argo/stages/deep_verify.py
+++ b/argo/stages/deep_verify.py
@@ -35,7 +35,7 @@ from ..context import BudgetExceeded, RunContext, atomic_write_json, collect_out
 from ..guardrails import assert_prohibited_present
 from ..models import Finding, Verification
 from ..ranking import dedup_key, split_ref
-from ..rendering import design_context_block, fill_placeholders, with_artifact_contract
+from ..rendering import design_context_block, render_prompt_pair, with_artifact_contract
 from ..runner import RunnerError
 from .validate import _build_excerpts
 
@@ -77,13 +77,12 @@ def _prior_verdicts(f: Finding) -> dict:
 
 
 def _build_prompt(ctx: RunContext, scope, scope_json_text: str, finding: Finding,
-                  siblings: list[Finding]) -> str:
-    template = (ctx.assets_dir / "09_deep_verify_prompt.md").read_text(encoding="utf-8")
+                  siblings: list[Finding]) -> tuple[str, str | None]:
     excerpts = _build_excerpts(
         ctx.repo_dir, finding.affected,
         ctx.config.excerpt_context_lines, ctx.config.excerpt_max_bytes,
     )
-    rendered = fill_placeholders(template, {
+    mapping = {
         "FINDING_JSON": json.dumps(finding.model_dump(exclude_none=True), indent=2),
         "PRIOR_VERDICTS_JSON": json.dumps(_prior_verdicts(finding), indent=2),
         "CODE_EXCERPTS": excerpts,
@@ -92,15 +91,22 @@ def _build_prompt(ctx: RunContext, scope, scope_json_text: str, finding: Finding
         "SCOPE_JSON": scope_json_text,
         "SIBLING_FINDINGS_JSON": json.dumps([_summarize(s) for s in siblings if s.id != finding.id],
                                             indent=2),
-    })
+    }
+    rendered, neutral_rendered = render_prompt_pair(ctx.assets_dir, "09_deep_verify_prompt.md", mapping)
     assert_prohibited_present(rendered, scope.prohibited_techniques)  # guardrail
-    rendered = (rendered.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
+
+    def _finish(text: str) -> str:
+        text = (text.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
                 "If this finding matches an accepted-by-design behavior listed above, return verdict "
                 "`refuted` with a rationale that names the accepted risk.")
-    return with_artifact_contract(rendered, artifacts=[{
-        "type": "deep_verify_verdict", "filename": f"deep_verify_{finding.id}.json", "schema": None,
-        "desc": "the deep-verify verdict for this single finding",
-    }])
+        return with_artifact_contract(text, artifacts=[{
+            "type": "deep_verify_verdict", "filename": f"deep_verify_{finding.id}.json", "schema": None,
+            "desc": "the deep-verify verdict for this single finding",
+        }])
+
+    prompt = _finish(rendered)
+    neutral_prompt = _finish(neutral_rendered) if neutral_rendered is not None else None
+    return prompt, neutral_prompt
 
 
 #: Fields the model sometimes echoes back as a placeholder-shaped STRING (copying the field's own
@@ -141,9 +147,11 @@ def _verify_one(ctx: RunContext, scope, scope_json_text: str, finding: Finding,
     for attempt in range(max_attempts):
         retrying = attempt + 1 < max_attempts
         work_label = finding.id if attempt == 0 else f"{finding.id}-retry{attempt}"
+        prompt, neutral_prompt = _build_prompt(ctx, scope, scope_json_text, finding, siblings)
         try:
             result = ctx.runner.run(
-                prompt=_build_prompt(ctx, scope, scope_json_text, finding, siblings),
+                prompt=prompt,
+                neutral_prompt=neutral_prompt,
                 run_dir=ctx.run_dir,
                 work_dir=ctx.work_dir("verify", work_label),   # fresh, isolated context per attempt
                 model=ctx.config.model_for("verify"),

--- a/argo/stages/validate.py
+++ b/argo/stages/validate.py
@@ -19,7 +19,7 @@ from ..grounding import build_index, ground_finding
 from ..guardrails import assert_prohibited_present, out_of_scope_match
 from ..models import Finding, Grounding, Validation
 from ..ranking import confidence_rank, dedup_key, severity_rank, split_ref
-from ..rendering import design_context_block, fill_placeholders, with_artifact_contract
+from ..rendering import design_context_block, fill_placeholders, render_prompt_pair, with_artifact_contract
 from ..runner import RunnerError
 
 _KEEP_VERDICTS = {"confirmed", "needs_runtime_verification"}
@@ -351,34 +351,39 @@ def _validate_one(ctx: RunContext, scope, scope_json_text: str, finding: Finding
         ctx.repo_dir, finding.affected,
         ctx.config.excerpt_context_lines, ctx.config.excerpt_max_bytes,
     )
-    template = (ctx.assets_dir / "02_adversarial_validation_prompt.md").read_text(encoding="utf-8")
-    rendered = fill_placeholders(template, {
+    mapping = {
         "FINDING_JSON": json.dumps(finding.model_dump(exclude_none=True), indent=2),
         "CODE_EXCERPTS": excerpts,
         "REPO_PATH": str(ctx.repo_dir.resolve()),
         "TARGET_TYPE": scope.target_type,
         "SCOPE_JSON": scope_json_text,
         "GROUND_TRUTH": _format_ground_truth(ground_truth, finding.source_focus),
-    })
+    }
+    rendered, neutral_rendered = render_prompt_pair(
+        ctx.assets_dir, "02_adversarial_validation_prompt.md", mapping)
     assert_prohibited_present(rendered, scope.prohibited_techniques)  # guardrail
 
     # Impact discipline (no reflexive IMDS-style escalation) + accepted-by-design context: a finding
     # matching a stated accepted risk should be refuted-as-out-of-scope rather than confirmed.
-    rendered = (rendered.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
+    def _finish(text: str) -> str:
+        text = (text.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
                 "If this finding matches an accepted-by-design behavior listed above, return verdict "
                 "`out_of_scope` with a rationale that names the accepted risk (it is intended, not a "
                 "vulnerability).")
+        return with_artifact_contract(
+            text,
+            artifacts=[{
+                "type": "verdict", "filename": f"verdict_{finding.id}.json", "schema": None,
+                "desc": "the adversarial validation verdict for this single finding",
+            }],
+        )
 
-    prompt = with_artifact_contract(
-        rendered,
-        artifacts=[{
-            "type": "verdict", "filename": f"verdict_{finding.id}.json", "schema": None,
-            "desc": "the adversarial validation verdict for this single finding",
-        }],
-    )
+    prompt = _finish(rendered)
+    neutral_prompt = _finish(neutral_rendered) if neutral_rendered is not None else None
     try:
         result = ctx.runner.run(
             prompt=prompt,
+            neutral_prompt=neutral_prompt,
             run_dir=ctx.run_dir,
             work_dir=ctx.work_dir("validate", finding.id),   # fresh, isolated context
             model=ctx.config.model_for("validate"),
@@ -431,25 +436,31 @@ def _validate_batch(ctx: RunContext, scope, scope_json_text: str, batch: list[Fi
                 ctx.config.excerpt_context_lines, ctx.config.excerpt_max_bytes),
             "ground_truth": _format_ground_truth(ground_truth, f.source_focus),
         })
-    template = (ctx.assets_dir / "02b_adversarial_validation_batch_prompt.md").read_text(encoding="utf-8")
-    rendered = fill_placeholders(template, {
+    mapping = {
         "FINDINGS_BATCH": json.dumps(items, indent=2),
         "REPO_PATH": str(ctx.repo_dir.resolve()),
         "TARGET_TYPE": scope.target_type,
         "SCOPE_JSON": scope_json_text,
-    })
+    }
+    rendered, neutral_rendered = render_prompt_pair(
+        ctx.assets_dir, "02b_adversarial_validation_batch_prompt.md", mapping)
     assert_prohibited_present(rendered, scope.prohibited_techniques)  # guardrail
-    rendered = (rendered.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
+
+    def _finish(text: str) -> str:
+        text = (text.rstrip() + "\n\n" + design_context_block(scope.accepted_risks) + "\n\n"
                 "If a finding matches an accepted-by-design behavior listed above, return verdict "
                 "`out_of_scope` for it with a rationale that names the accepted risk.")
-    prompt = with_artifact_contract(rendered, artifacts=[{
-        "type": "verdicts", "filename": "verdicts.json", "schema": None,
-        "desc": "a JSON object {\"verdicts\": [...]} with ONE adversarial verdict per finding_id in the batch",
-    }])
+        return with_artifact_contract(text, artifacts=[{
+            "type": "verdicts", "filename": "verdicts.json", "schema": None,
+            "desc": "a JSON object {\"verdicts\": [...]} with ONE adversarial verdict per finding_id in the batch",
+        }])
+
+    prompt = _finish(rendered)
+    neutral_prompt = _finish(neutral_rendered) if neutral_rendered is not None else None
     ids = [f.id for f in batch]
     try:
         result = ctx.runner.run(
-            prompt=prompt, run_dir=ctx.run_dir,
+            prompt=prompt, neutral_prompt=neutral_prompt, run_dir=ctx.run_dir,
             work_dir=ctx.work_dir("validate", "batch-" + ids[0]),   # fresh, isolated context
             model=ctx.config.model_for("validate"), stage="validate",
             run_id=ctx.run_id, repo_dir=ctx.repo_dir,               # READ-ONLY

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -318,6 +318,38 @@ Concrete backends (all subclasses of `AgentRunner`, dispatched by `build_runner`
   an immediate moderation flag/credit failure killed the whole run without ever trying a configured
   fallback backend, on exactly the failure shape fallback exists for.
 
+  **Same-backend retry with a neutral-register prompt variant.** `AgentRunner.run()` itself (the
+  base class, so it applies to every backend and every fallback-chain configuration — including a
+  single backend with no chain at all) accepts an optional `neutral_prompt` alongside `prompt`. On a
+  `moderation_flagged` failure it retries **once**, on the **same backend**, with `neutral_prompt` in
+  place of `prompt`, after a short `_NEUTRAL_RETRY_DELAY_S` pause — deliberately much shorter than
+  `FallbackRunner`'s 90s same-provider cooldown above, since that duration exists because *identical*
+  back-to-back retries of the same prompt kept flagging; a differently-worded prompt is a materially
+  different input to the classifier, so the same justification doesn't hold at full strength. Internally
+  `run()` is a thin wrapper around `_run_attempt()` (the renamed original single-attempt body), so
+  both attempts flow through the normal ledger/`llm_log.jsonl` logging independently — the audit
+  trail shows the flag and the recovery. A caller that never passes `neutral_prompt` sees
+  byte-identical behavior to a plain single attempt; `FallbackRunner` and the orchestrator need no
+  changes at all, since they only ever see `run()`'s final outcome. This is the third of three
+  independent, non-overlapping resilience layers — prompt variant (this), backend
+  (`FallbackRunner`, above), whole stage (orchestrator, below) — each solving a different question
+  ("wrong wording?", "wrong provider?", "needs more real time to pass?") with zero interaction risk
+  between them.
+
+  Stages build a `neutral_prompt` two different ways, matching how their prompt is built in the
+  first place: **static-template stages** (`validate`, `deep_verify`) use `rendering.render_prompt_pair`,
+  which renders the normal template plus a hand-authored `<name>.neutral.md` companion file if one
+  exists (e.g. `02_adversarial_validation_prompt.neutral.md`) — a one-time authoring cost, zero
+  runtime cost, `None` if no companion exists. The **audit stage** has no static per-focus template
+  to pair (its prompts are prose the recon-synthesis model writes itself, matching
+  `01_audit_prompt_template.md.j2` as a reference — see [prompt-synthesis.md](prompt-synthesis.md)),
+  so it instead calls `rendering.neutralize_audit_prompt`: a deterministic, zero-LLM-cost,
+  case-preserving word-substitution pass over the already-rendered text (`attacker` → "an untrusted
+  caller", `exploit(able)` → "trigger(able)", etc.), which skips the PROHIBITED TECHNIQUES block
+  entirely so the scope's verbatim constraints survive, and is re-checked against
+  `guardrails.assert_prohibited_present` before use (falling back to no neutral variant, not a
+  weakened prompt, if the rewrite ever trips that guardrail).
+
 The real backends launch the CLI through `AgentRunner._exec`, a **cancellable** subprocess: a pump
 thread runs `communicate` while the main thread polls `self.cancel_event` (set by the orchestrator
 for the run). On Cancel it kills the whole process **tree** (`_kill_tree`: `taskkill /T` on Windows,

--- a/docs/headless-runner.md
+++ b/docs/headless-runner.md
@@ -75,6 +75,13 @@ Every `RunnerError` these paths raise also carries a classified `failure_kind`
 classification applies to both backends via the shared `AgentRunner.run()`, not just Codex, even
 though Codex's exit_1/0-token crash signature is where it matters most in practice).
 
+A `moderation_flagged` failure specifically also gets a **same-backend retry with a neutral-register
+prompt variant**, if the calling stage supplied one (`run(..., neutral_prompt=...)`) — one bounded
+retry, no LLM call needed to produce the variant (a hand-authored companion template for
+validate/deep_verify, a deterministic word-substitution pass for audit's model-generated prose). See
+[architecture.md](architecture.md#the-agentrunner-abstraction) for the full mechanism; this is
+independent of `FallbackRunner`'s cross-backend retry described above.
+
 **Partial recovery:** `stages/audit.py` and `stages/recon.py` catch a hard `RunnerError` and try
 to recover whatever the session already wrote to its scratch dir before failing — so one timed-out
 or crashed session does not lose a whole focus (audit) or the generated prompts (recon).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ construction, and the subprocess error paths with crafted inputs and fakes (stil
 
 ```bash
 pip install -r requirements.txt
-python -m pytest tests/ -q          # 358 tests (incl. the HTTP API + UI serving on the mock runner)
+python -m pytest tests/ -q          # 366 tests (incl. the HTTP API + UI serving on the mock runner)
 ```
 
 `pytest.ini` pins `--basetemp=.pytest_tmp` so the read-only repo copies the pipeline creates do
@@ -19,7 +19,7 @@ not trip Windows' global temp rotation.
 | File | Covers |
 |---|---|
 | `test_guardrails.py` | tool-allowlist stripping, `assert_no_network_tools`, **the `research`-stage OSINT carve-out** (research keeps WebSearch/WebFetch but loses the shell; every other stage stays offline), prohibited-technique present/missing/empty, audit-prompt well-formedness, placeholder/`.j2` rendering |
-| `test_units.py` | `split_ref` / `dedup_key`, manifest extraction + glob fallback, schema conformance of fixtures, artifact-contract shape |
+| `test_units.py` | `split_ref` / `dedup_key`, manifest extraction + glob fallback, schema conformance of fixtures, artifact-contract shape; **neutral-register prompts** — `render_prompt_pair` finds/renders a `.neutral.md` companion or returns `None` when absent, `neutralize_audit_prompt` softens narrative vocabulary while leaving the PROHIBITED TECHNIQUES block byte-identical |
 | `test_runner.py` | the runner strips network/mutation tools even when a stage requests them; headless command is read-only/sandboxed |
 | `test_headless.py` | strict parser over the **real** captured envelope, shape-drift fail-loud, recoverable-vs-API-error classification, turn/cost caps, `--max-budget-usd` present / no `--max-turns`, session-budget math, empty/malformed/non-zero-exit handling, audit partial-recovery |
 | `test_links.py` | `--links` parsing/normalization/merge, repo-drop safety rule, schema survival, propagation into a rendered prompt, backward compatibility |
@@ -38,6 +38,7 @@ not trip Windows' global temp rotation.
 | `test_orchestrator_retry.py` | **orchestrator-level auto-retry**: `_run_stage_sequence` retries a retryable stage failure in place (bounded, real sleep mocked in tests) and can still succeed; retries are capped then propagate; `credits_exhausted` and a non-retryable failure are never auto-retried; a reset hint further out than the auto-retry sleep cap is not waited for (surfaces normally instead of hanging an unattended run); a cancelled run is never retried |
 | `test_context.py` | **`atomic_write_json`**: writes correct content and leaves no leftover `.tmp` file, creates missing parent directories, a write that fails before the atomic replace never touches the last-good file on disk, retries a transient Windows `PermissionError` then succeeds, and raises (rather than silently dropping the write) after a persistent one |
 | `test_cli_resume_hint.py` | **`cli._run_with_resume_hint`**: returns the wrapped callable's result on success; on a real failure OR a `KeyboardInterrupt` (Ctrl+C is the most likely real-world interruption), prints the exact `argo resume <run_id>` command before re-raising; a clean `typer.Exit` passes through silently (no false-alarm resume hint on ordinary CLI control flow) |
+| `test_neutral_retry.py` | **neutral-register moderation-flag recovery**: `AgentRunner.run()` retries once, same backend, with a caller-supplied `neutral_prompt` on a `moderation_flagged` failure (short delay, distinct from `FallbackRunner`'s 90s same-provider cooldown); no retry when `neutral_prompt` is omitted (byte-identical to pre-feature behavior); no retry for any other failure kind; bounded to exactly one retry even if the neutral variant also flags |
 
 ## The two zero-cost modes
 

--- a/tests/test_neutral_retry.py
+++ b/tests/test_neutral_retry.py
@@ -1,0 +1,96 @@
+"""AgentRunner.run()'s same-backend retry with a caller-supplied neutral-register prompt variant
+on a moderation-flagged failure (see runner.py: run()/_run_attempt()/_NEUTRAL_RETRY_DELAY_S).
+
+This is deliberately independent of FallbackRunner's cross-backend retry (test_fallback.py) and
+the orchestrator's whole-stage auto-retry (test_orchestrator_retry.py) -- three separate layers.
+"""
+
+import argo.runner as runner_mod
+import pytest
+
+from argo.config import PipelineConfig
+from argo.ledger import Ledger
+from argo.runner import LLMResult, MockClaudeRunner, RunnerError
+
+
+def _runner(tmp_path):
+    return MockClaudeRunner(PipelineConfig(runner="mock"), Ledger(tmp_path / "l.sqlite"))
+
+
+def _kwargs(tmp_path, **overrides):
+    kw = dict(prompt="normal prompt", run_dir=tmp_path, work_dir=tmp_path / "work",
+              model="m", stage="audit", run_id="R", label="x")
+    kw.update(overrides)
+    return kw
+
+
+def _flag(msg="flagged"):
+    raise RunnerError(msg, retryable=True, failure_kind="moderation_flagged")
+
+
+def test_retries_once_with_neutral_prompt_on_moderation_flag(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    calls, slept = [], []
+
+    def fake_attempt(self, *, prompt, **kw):
+        calls.append(prompt)
+        if prompt == "normal prompt":
+            _flag()
+        return LLMResult(text="ok", model="m", prompt_sha256="h", work_dir=tmp_path)
+
+    monkeypatch.setattr(MockClaudeRunner, "_run_attempt", fake_attempt)
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda s: slept.append(s))
+    result = r.run(**_kwargs(tmp_path, neutral_prompt="neutral prompt"))
+    assert result.text == "ok"
+    assert calls == ["normal prompt", "neutral prompt"]
+    # short, reasoned delay -- NOT FallbackRunner's 90s same-provider cooldown (see
+    # runner._MODERATION_RETRY_DELAY's own docstring for why the two are deliberately different).
+    assert slept == [runner_mod._NEUTRAL_RETRY_DELAY_S]
+    r.ledger.close()
+
+
+def test_no_retry_when_no_neutral_prompt_supplied(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    calls = []
+
+    def fake_attempt(self, *, prompt, **kw):
+        calls.append(prompt)
+        _flag()
+
+    monkeypatch.setattr(MockClaudeRunner, "_run_attempt", fake_attempt)
+    with pytest.raises(RunnerError):
+        r.run(**_kwargs(tmp_path))   # neutral_prompt defaults to None
+    assert calls == ["normal prompt"]   # exactly one attempt -- byte-identical to pre-change behavior
+    r.ledger.close()
+
+
+def test_no_retry_for_a_different_failure_kind(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    calls = []
+
+    def fake_attempt(self, *, prompt, **kw):
+        calls.append(prompt)
+        raise RunnerError("rate limited", retryable=True, failure_kind="rate_limited")
+
+    monkeypatch.setattr(MockClaudeRunner, "_run_attempt", fake_attempt)
+    with pytest.raises(RunnerError):
+        r.run(**_kwargs(tmp_path, neutral_prompt="neutral prompt"))
+    assert calls == ["normal prompt"]   # neutral_prompt is only ever used for moderation_flagged
+    r.ledger.close()
+
+
+def test_bounded_to_one_retry_even_if_the_neutral_variant_also_flags(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    calls = []
+
+    def fake_attempt(self, *, prompt, **kw):
+        calls.append(prompt)
+        _flag()
+
+    monkeypatch.setattr(MockClaudeRunner, "_run_attempt", fake_attempt)
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda s: None)
+    with pytest.raises(RunnerError) as exc_info:
+        r.run(**_kwargs(tmp_path, neutral_prompt="neutral prompt"))
+    assert calls == ["normal prompt", "neutral prompt"]   # no recursion / infinite loop
+    assert exc_info.value.failure_kind == "moderation_flagged"
+    r.ledger.close()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import pytest
 
 from argo.ranking import dedup_key, split_ref, severity_rank, confidence_rank
-from argo.rendering import extract_manifest, with_artifact_contract
+from argo.rendering import (extract_manifest, neutralize_audit_prompt, render_prompt_pair,
+                            with_artifact_contract)
 from argo.schemas import SchemaValidationError, validate_findings, validate_scope
 from argo.runner import LLMResult
 from argo.context import collect_output_files
@@ -215,3 +216,50 @@ def test_artifact_contract_mentions_readonly_and_manifest():
     assert "READ-ONLY" in out
     assert "f.json" in out
     assert "```json" in out  # manifest contract present
+
+
+# ------------------------------------------------------------ neutral-register workaround
+def test_render_prompt_pair_finds_the_neutral_companion(tmp_path):
+    (tmp_path / "t.md").write_text("Hello {{NAME}}.", encoding="utf-8")
+    (tmp_path / "t.neutral.md").write_text("Hi there {{NAME}}.", encoding="utf-8")
+    prompt, neutral = render_prompt_pair(tmp_path, "t.md", {"NAME": "world"})
+    assert prompt == "Hello world."
+    assert neutral == "Hi there world."
+
+
+def test_render_prompt_pair_without_a_companion_returns_none(tmp_path):
+    (tmp_path / "t.md").write_text("Hello {{NAME}}.", encoding="utf-8")
+    prompt, neutral = render_prompt_pair(tmp_path, "t.md", {"NAME": "world"})
+    assert prompt == "Hello world."
+    assert neutral is None
+
+
+def test_neutralize_audit_prompt_softens_narrative_vocabulary():
+    text = (
+        "## ATTACK SURFACES TO COVER\n"
+        "Identify exploitable vulnerabilities reachable by an attacker-controlled input. "
+        "Be adversarial but evidence-driven.\n"
+    )
+    out = neutralize_audit_prompt(text)
+    assert "exploitable" not in out and "triggerable" in out
+    assert "attacker-controlled" not in out and "externally-controlled" in out
+    assert "adversarial" not in out and "challenging" in out
+    # the audit task's own inherent vocabulary is untouched -- only the framing is softened
+    assert "vulnerabilities" in out
+
+
+def test_neutralize_audit_prompt_preserves_the_prohibited_techniques_block_verbatim():
+    text = (
+        "## SCOPE & RULES OF ENGAGEMENT\n\n"
+        "PROHIBITED TECHNIQUES (hard limits):\n"
+        "- no attacks against production infrastructure\n"
+        "- no attacker-controlled DoS or malicious payloads to live hosts\n\n"
+        "## ROLE\n"
+        "Find exploitable vulnerabilities via attacker-controlled input.\n"
+    )
+    out = neutralize_audit_prompt(text)
+    prohibited_block, after_role = out.split("## ROLE")
+    assert "no attacks against production infrastructure" in prohibited_block
+    assert "no attacker-controlled DoS or malicious payloads to live hosts" in prohibited_block
+    assert "exploitable" not in after_role and "triggerable" in after_role
+    assert "attacker-controlled" not in after_role and "externally-controlled" in after_role


### PR DESCRIPTION
## Summary
- `AgentRunner.run()` gains an optional `neutral_prompt` alongside `prompt`. On a `moderation_flagged` failure it retries **once**, on the **same backend**, with the neutral variant in place of the original, after a short delay — orthogonal to `FallbackRunner`'s cross-backend retry and the orchestrator's whole-stage auto-retry (three independent, non-overlapping resilience layers).
- Static-template stages (`validate`, `deep_verify`) get hand-authored `*.neutral.md` companion files via a new `rendering.render_prompt_pair` helper.
- The audit stage has no static per-focus template (its prompts are prose the recon-synthesis model writes itself), so it uses a new `rendering.neutralize_audit_prompt`: a deterministic, zero-LLM-cost word-substitution pass over the already-rendered text, which skips the PROHIBITED TECHNIQUES block entirely and is re-checked against `assert_prohibited_present` before use.
- Reactive by design: the normal prompt goes out by default everywhere, so there is zero added cost unless a call actually gets flagged.

## Test plan
- [x] Full suite green
- [x] New coverage: `tests/test_neutral_retry.py` (retries once with `neutral_prompt` on `moderation_flagged`, no retry without one, no retry for a different failure kind, bounded to one retry even if the neutral variant also flags), plus `render_prompt_pair`/`neutralize_audit_prompt` unit tests in `tests/test_units.py`
- [x] Docs updated: `docs/architecture.md`, `docs/headless-runner.md`, `docs/testing.md`
- [x] Real-world sanity: exercised the surrounding resilience machinery end-to-end on a real target tonight (goqite) — the moderation-flag path itself didn't happen to fire, but `FallbackRunner`'s cross-backend retry and the per-finding retry loops all fired for real and recovered correctly