### PR TITLE
ledger: combine a run's cost/call-count with its second-opinion children

### DIFF
--- a/argo/ledger.py
+++ b/argo/ledger.py
@@ -121,18 +121,34 @@ class Ledger:
             )
             self._conn.commit()
 
+    @staticmethod
+    def _run_id_and_children(run_id: str) -> tuple[str, str]:
+        """A second-opinion blind pass runs under its own child run_id
+        (``f"{run_id}-so{pass_index}"``, see stages/second_opinion.py) so its artifacts land in an
+        isolated run_dir -- but it is still spend incurred BY this run, not a separate one, so every
+        cost/count query must combine the two rather than silently undercounting whichever passes
+        happen to have a different run_id. ``%``/`_` are escaped since they are SQL LIKE wildcards;
+        real run_ids (``new_run_id()``: a timestamp + 6 hex chars) never contain either, but nothing
+        stops a caller from passing an arbitrary string here."""
+        escaped = run_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        return run_id, escaped + "-so%"
+
     def run_cost(self, run_id: str) -> float:
+        exact, children_pattern = self._run_id_and_children(run_id)
         with self._lock:
             row = self._conn.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) AS c FROM llm_calls WHERE run_id = ?",
-                (run_id,),
+                "SELECT COALESCE(SUM(cost_usd), 0.0) AS c FROM llm_calls "
+                "WHERE run_id = ? OR run_id LIKE ? ESCAPE '\\'",
+                (exact, children_pattern),
             ).fetchone()
         return float(row["c"])
 
     def run_call_count(self, run_id: str) -> int:
+        exact, children_pattern = self._run_id_and_children(run_id)
         with self._lock:
             row = self._conn.execute(
-                "SELECT COUNT(*) AS n FROM llm_calls WHERE run_id = ?", (run_id,)
+                "SELECT COUNT(*) AS n FROM llm_calls WHERE run_id = ? OR run_id LIKE ? ESCAPE '\\'",
+                (exact, children_pattern),
             ).fetchone()
         return int(row["n"])
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -463,7 +463,13 @@ findings_ledger(id, ts, program_name, run_id, dedup_key, title, verdict, validat
                 UNIQUE(program_name, dedup_key, run_id))
 ```
 
-- `llm_calls` powers cost control and the hard per-run `--budget` guard (`run_cost()`).
+- `llm_calls` powers cost control and the hard per-run `--budget` guard (`run_cost()`). A
+  second-opinion blind pass (`--second-opinion N`) runs under its own child run_id
+  (`f"{run_id}-so{N}"`, its own isolated `run_dir`) but the **same** ledger file — `run_cost()`/
+  `run_call_count()` combine a run_id with any `-soN` children by design, so the `--budget` ceiling
+  and the reported `cost_usd` reflect the run's TRUE total spend, not just the primary pass's own
+  rows. (Found the hard way: before this, a second-opinion pass got a full fresh budget allowance
+  independent of what the primary had already spent, since its rows lived under a different run_id.)
 - `findings_ledger` detects cross-run/cross-program resubmission (`prior_sightings()`), which
   Stage 5 surfaces as a "possible resubmissions" section.
 - The `triager_*` columns hold **real-world feedback** (A2): `record_triager_feedback()` ingests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ construction, and the subprocess error paths with crafted inputs and fakes (stil
 
 ```bash
 pip install -r requirements.txt
-python -m pytest tests/ -q          # 366 tests (incl. the HTTP API + UI serving on the mock runner)
+python -m pytest tests/ -q          # 371 tests (incl. the HTTP API + UI serving on the mock runner)
 ```
 
 `pytest.ini` pins `--basetemp=.pytest_tmp` so the read-only repo copies the pipeline creates do
@@ -20,6 +20,7 @@ not trip Windows' global temp rotation.
 |---|---|
 | `test_guardrails.py` | tool-allowlist stripping, `assert_no_network_tools`, **the `research`-stage OSINT carve-out** (research keeps WebSearch/WebFetch but loses the shell; every other stage stays offline), prohibited-technique present/missing/empty, audit-prompt well-formedness, placeholder/`.j2` rendering |
 | `test_units.py` | `split_ref` / `dedup_key`, manifest extraction + glob fallback, schema conformance of fixtures, artifact-contract shape; **neutral-register prompts** — `render_prompt_pair` finds/renders a `.neutral.md` companion or returns `None` when absent, `neutralize_audit_prompt` softens narrative vocabulary while leaving the PROHIBITED TECHNIQUES block byte-identical |
+| `test_ledger.py` | `Ledger.run_cost`/`run_call_count` combine a run with its second-opinion children (`-soN`) so the `--budget` ceiling and reported cost reflect TRUE total spend, not just the primary pass's own rows; unrelated runs never leak into each other's total; a run_id containing a literal `%`/`_` doesn't turn into an unintended LIKE wildcard |
 | `test_runner.py` | the runner strips network/mutation tools even when a stage requests them; headless command is read-only/sandboxed |
 | `test_headless.py` | strict parser over the **real** captured envelope, shape-drift fail-loud, recoverable-vs-API-error classification, turn/cost caps, `--max-budget-usd` present / no `--max-turns`, session-budget math, empty/malformed/non-zero-exit handling, audit partial-recovery |
 | `test_links.py` | `--links` parsing/normalization/merge, repo-drop safety rule, schema survival, propagation into a rendered prompt, backward compatibility |

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,59 @@
+"""Ledger.run_cost/run_call_count must combine a run with its second-opinion children
+(stages/second_opinion.py's ``f"{run_id}-so{N}"`` blind passes) -- they run in an isolated run_dir
+for artifact cleanliness, but their spend is still incurred BY the parent run. Found for real: a
+$15 --budget ceiling on a run with second_opinion_passes=1 actually allowed ~$34 real spend because
+the budget check (RunContext.assert_budget / AgentRunner._session_budget) queried only the primary
+run_id's own cost, silently missing the child pass's spend sitting under a different run_id in the
+SAME ledger file."""
+
+from argo.ledger import Ledger
+
+
+def _log(ledger: Ledger, run_id: str, cost: float) -> None:
+    ledger.log_call(run_id=run_id, stage="audit", model="m", prompt_sha256="h", cost_usd=cost)
+
+
+def test_run_cost_combines_second_opinion_children(tmp_path):
+    ledger = Ledger(tmp_path / "l.sqlite")
+    _log(ledger, "R", 1.0)
+    _log(ledger, "R-so1", 2.0)
+    _log(ledger, "R-so2", 3.0)
+    assert ledger.run_cost("R") == 6.0
+    ledger.close()
+
+
+def test_run_cost_does_not_leak_into_unrelated_runs(tmp_path):
+    ledger = Ledger(tmp_path / "l.sqlite")
+    _log(ledger, "R", 1.0)
+    _log(ledger, "R-so1", 2.0)
+    _log(ledger, "R2", 100.0)          # unrelated run, must not be counted
+    _log(ledger, "R2-so1", 100.0)      # unrelated run's own child, must not be counted
+    assert ledger.run_cost("R") == 3.0
+    assert ledger.run_cost("R2") == 200.0
+    ledger.close()
+
+
+def test_run_call_count_combines_second_opinion_children(tmp_path):
+    ledger = Ledger(tmp_path / "l.sqlite")
+    _log(ledger, "R", 1.0)
+    _log(ledger, "R-so1", 1.0)
+    _log(ledger, "R-so1", 1.0)
+    assert ledger.run_call_count("R") == 3
+    ledger.close()
+
+
+def test_run_cost_escapes_like_wildcards_in_run_id(tmp_path):
+    """A run_id containing a literal '%' or '_' (never produced by new_run_id(), but not otherwise
+    forbidden) must not turn into an unintended LIKE wildcard that matches unrelated run_ids."""
+    ledger = Ledger(tmp_path / "l.sqlite")
+    _log(ledger, "R_1", 1.0)
+    _log(ledger, "RX1-so1", 5.0)   # would match "R_1-so%" if '_' were left unescaped -- must NOT
+    assert ledger.run_cost("R_1") == 1.0
+    ledger.close()
+
+
+def test_run_cost_with_no_calls_is_zero(tmp_path):
+    ledger = Ledger(tmp_path / "l.sqlite")
+    assert ledger.run_cost("nonexistent") == 0.0
+    assert ledger.run_call_count("nonexistent") == 0
+    ledger.close()


### PR DESCRIPTION
## Summary
`Ledger.run_cost`/`run_call_count` only ever queried the exact `run_id` passed in, but a second-opinion blind pass (`--second-opinion N`) runs under a child `run_id` (`f"{run_id}-so{N}"`) in the **same** ledger file — so the `--budget` hard ceiling and the reported `cost_usd` silently missed its spend entirely.

Found via a real run tonight: a $15 `--budget` cap on a run with `second_opinion_passes=1` allowed **~$34 real spend**, because the primary and the second-opinion pass each got their own full, independent budget allowance. A second attempt with a $75 cap allowed **~$80 real spend** for the primary alone plus its second-opinion pass, confirmed via the (now-fixed) combined query against the real ledger.

Fix: `run_cost`/`run_call_count` now sum a run_id's own rows plus any `-soN` children (LIKE-pattern match, with `%`/`_` escaped in case a run_id ever contains either — real run_ids never do, but nothing enforced that).

## Test plan
- [x] Full suite green
- [x] New coverage: `tests/test_ledger.py` — combines primary + children, does not leak into unrelated runs, escapes LIKE wildcards in a run_id, zero-calls case
- [x] Docs updated: `docs/architecture.md`, `docs/testing.md`