### PR TITLE
release: adopt Semantic Versioning + first tracked release (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to Argo are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) — see
+[docs/releasing.md](docs/releasing.md) for what that means concretely for this project, in
+particular while the version stays `0.y.z`.
+
+## [Unreleased]
+
+## [0.2.0] - 2026-08-14
+
+First formally tracked release. Argo has been under active development since 2026-06-18 (99
+commits) without a real version/release process; rather than reconstruct that history after the
+fact, this entry is a snapshot of what the pipeline can do today, and the changelog is precise from
+here forward.
+
+### Added
+
+- Core pipeline: ingest → recon → audit → validate → report.
+- Opt-in stages: deep verification (`deep_verify`), corroboration, second-opinion
+  reconciliation across independent audit passes, dependency/SCA scanning, sandboxed
+  runtime verification (loopback-only, `--network=none`), live authorized-target probing,
+  mechanical fix generation + re-audit, and sandboxed AddressSanitizer/UBSan PoC generation
+  for C/C++ memory-safety findings.
+- Multi-backend support (Claude Code, Codex, local open-source models) with cross-backend
+  fallback, failure-kind-aware retry/backoff, and a neutral-register recovery path for
+  moderation-flagged sessions.
+- HTTP API (`server/`) and a no-build web UI (`webapp/`) for run lifecycle, live status, and
+  history.
+- 388 tests, zero-token by default via a mock runner; a Docker-gated real end-to-end proof for
+  the sandboxed stages.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Tests](https://github.com/gigioneggiando/argo/actions/workflows/tests.yml/badge.svg)](https://github.com/gigioneggiando/argo/actions/workflows/tests.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/gigioneggiando/argo)](https://github.com/gigioneggiando/argo/releases)
 
 > *Argus Panoptes, the all-seeing watchman — a hundred eyes on your code.*
 
-🌐 **Live findings:** [gigioneggiando.github.io/argo](https://gigioneggiando.github.io/argo/) — real vulnerabilities Argo found, disclosed as public PRs · 📖 [Wiki](https://github.com/gigioneggiando/argo/wiki) · 💬 [Discussions](https://github.com/gigioneggiando/argo/discussions)
+🌐 **Live findings:** [gigioneggiando.github.io/argo](https://gigioneggiando.github.io/argo/) — real vulnerabilities Argo found, disclosed as public PRs · 📖 [Wiki](https://github.com/gigioneggiando/argo/wiki) · 💬 [Discussions](https://github.com/gigioneggiando/argo/discussions) · 📋 [Changelog](CHANGELOG.md)
 
 Argo finds security vulnerabilities in **source code** by driving an LLM as the analyst — it reads
 the code the way a human auditor would, rather than matching rules against a graph. Point it at any

--- a/argo/__init__.py
+++ b/argo/__init__.py
@@ -14,4 +14,4 @@ Hard guardrails are enforced in code (not just in prompts):
   * every LLM call is logged (prompt hash, model, token cost).
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ see the [top-level README](../README.md).
 | [testing.md](testing.md) | developers | Running the suite, coverage map, mock vs. headless, fixtures |
 | [runtime-verification-study.md](runtime-verification-study.md) | reviewers / security | The **opt-in, sandboxed runtime verification** design: the loopback-only sealed-container safety model, the propose→validate→execute→interpret flow, provisioning, and the R1–R4 plan |
 | [roadmap.md](roadmap.md) | everyone | Planned UI + advanced features: per-feature analysis (feasibility/utility/priority), phased build order, and the todo list |
+| [releasing.md](releasing.md) | maintainers | The SemVer convention, what bumps what, and the exact steps to cut a release |
 
 ## Diagrams
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,45 @@
+# Releasing
+
+Argo follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — `MAJOR.MINOR.PATCH`.
+
+While the version stays `0.y.z` ("initial development", per the spec), anything may change between
+minor versions without a major bump: the CLI flags, config fields, JSON schemas, and HTTP API are
+not yet considered stable. Reaching `1.0.0` will be a deliberate signal that they are — not a
+default to reach for once the feature list looks big enough.
+
+## What bumps what
+
+- **PATCH** (`0.2.0` → `0.2.1`) — a bug fix, no CLI/config/schema/API change.
+- **MINOR** (`0.2.0` → `0.3.0`) — a new capability, flag, stage, or endpoint that's additive;
+  existing usage keeps working unchanged. Most releases land here.
+- **A breaking change** (renaming/removing a CLI flag, an incompatible JSON schema change, a
+  breaking HTTP API change) — normally MAJOR, but while pre-1.0 SemVer allows folding this into a
+  MINOR bump instead (the public surface isn't stable yet). Call it out clearly under its own
+  `### Changed` / `### Removed` heading in the changelog either way, so it's easy to scan for.
+
+## Cutting a release
+
+1. Update the version in the two places it's declared by hand (no build-time templating, kept in
+   sync manually — small enough surface that automating this isn't worth it yet):
+   - `pyproject.toml` → `[project] version`
+   - `argo/__init__.py` → `__version__`
+2. Move `CHANGELOG.md`'s `[Unreleased]` section into a new `## [X.Y.Z] - YYYY-MM-DD` section, with
+   real content (don't ship an empty release).
+3. Commit: `git commit -m "release: vX.Y.Z"`, through the normal PR flow like any other change.
+4. After merge, tag the merge commit on `main` and push the tag:
+   `git tag vX.Y.Z && git push origin vX.Y.Z`.
+5. Publish a GitHub Release from the tag, reusing that same changelog section as the release notes:
+   `gh release create vX.Y.Z --title vX.Y.Z --notes-file path/to/notes.md` (paste the section's body
+   into a scratch file first — trying to slice it out of `CHANGELOG.md` with a one-liner isn't worth
+   the fragility for something this infrequent).
+
+There's no PyPI publish yet — `pip install` today means `pip install -e .` from a checkout (see the
+top-level [README.md](../README.md)). An automated publish-on-tag workflow is a reasonable next
+step once that's actually wanted; it isn't part of this process yet, so don't build it preemptively.
+
+## Why the version number isn't cosmetic
+
+Every report Argo produces carries `v{__version__}` in its footer (`argo/branding.py`) — it's
+already live in real disclosure reports sent to real maintainers. Bump it because something
+actually changed, not on a schedule, and not to make the project look more mature than the CLI/API
+surface actually is.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argo-audit"
-version = "0.1.0"
+version = "0.2.0"
 description = "Argo — AI source-static security-audit pipeline for bug-bounty programs"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Adopts **Semantic Versioning** (`MAJOR.MINOR.PATCH`) as Argo's release convention, staying in the `0.y.z` range for now — the CLI/config/schema/HTTP-API surface is still changing weekly, so `1.0.0` is a signal to earn, not claim on day one.
- Adds `CHANGELOG.md` (Keep a Changelog format) and `docs/releasing.md` (the convention, what bumps what, and the exact steps to cut a release).
- Bumps the version already declared in `pyproject.toml`/`argo/__init__.py` from the never-released `0.1.0` placeholder to `0.2.0` as the first formally tracked release.
- README gets a version badge + changelog link; `docs/README.md` gets a `releasing.md` index row.

Why SemVer over CalVer or a date/4-part scheme: the project is already PEP 621-packaged for pip (which assumes SemVer-shaped versions), the version string is already embedded live in every disclosure report's footer, and there's a real API/CLI/schema surface where "is it safe to upgrade" (SemVer's whole point) matters more than "when was this built" (CalVer's).

## Test plan
- [x] `python -m pytest tests/ -q` — 388 passed.
- [x] Grepped for stale `0.1.0` references elsewhere in the codebase — none.
- [ ] After merge: tag `v0.2.0` on the merge commit, push the tag, publish a GitHub Release from it.

https://claude.ai/code/session_01WKGXWqUr7or13ZN8Mx9Pdm