### PR TITLE
docs: fix stale test count in the repo quick-map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ BUILD_SPEC.md             the spec the orchestrator was built against
 argo/                 the orchestrator (see architecture.md)
 server/                   the HTTP API on top of the pipeline (see api.md)
 webapp/                   the no-build web UI (see ui.md)
-tests/                    186 tests, zero-token by default (see testing.md)
+tests/                    388 tests, zero-token by default (see testing.md)
 docs/                     you are here
 docs/legacy/              archived reference artifacts (e.g. the original META_PROMPT_generator)
 runs/<RUN_ID>/            per-run artifacts (git-ignored)


### PR DESCRIPTION
Trivial: `docs/README.md`'s quick-map said 186 tests, actual current count is 388. Caught while auditing the wiki for staleness after the ASan PoC stage / release-process work.