### PR TITLE
docs: lead README with real disclosed results, trim to point at docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,39 +6,61 @@
 
 > *Argus Panoptes, the all-seeing watchman — a hundred eyes on your code.*
 
-🌐 **Live findings:** [gigioneggiando.github.io/argo](https://gigioneggiando.github.io/argo/) — real vulnerabilities Argo found, disclosed as public PRs · 📖 [Wiki](https://github.com/gigioneggiando/argo/wiki) · 💬 [Discussions](https://github.com/gigioneggiando/argo/discussions) · 📋 [Changelog](CHANGELOG.md)
+🌐 **Live findings:** [gigioneggiando.github.io/argo](https://gigioneggiando.github.io/argo/) · 📖 [Wiki](https://github.com/gigioneggiando/argo/wiki) · 💬 [Discussions](https://github.com/gigioneggiando/argo/discussions) · 📋 [Changelog](CHANGELOG.md)
+
+## Real, disclosed, independently verified
+
+Not a benchmark score — pull requests, published advisories, and a CVE, on real open-source projects.
+
+**10** projects audited and disclosed · **41** public PRs · **38** already resolved · **91% real-world accuracy**\*
+
+| Project | Stars | Severity | Result |
+|---|---:|---|---|
+| [ds4](https://github.com/antirez/ds4) — antirez, Redis's original author | 21k★ | Critical | Pre-auth double-free, fixed |
+| [moquette](https://github.com/moquette-io/moquette) | 2.4k★ | Critical | Authz bypass, [advisory published](https://github.com/moquette-io/moquette/security/advisories/GHSA-5f42-97gr-vfhq) |
+| [PocketBase](https://github.com/pocketbase/pocketbase) | 61k★ | High (8.7) | [Advisory published](https://github.com/pocketbase/pocketbase/security/advisories/GHSA-84vh-m24q-wjjx), reporter credited |
+| [LiveKit](https://github.com/livekit/livekit) | 20k★ | Critical + High | 13 of 19 findings fixed, credited on their [Security Hall of Fame](https://livekit.com/security/hall-of-fame) |
+| [coturn](https://github.com/coturn/coturn) | 14k★ | Medium | Real CVE assigned: [CVE-2026-73213](https://github.com/coturn/coturn/security/advisories/GHSA-4v97-rxjj-4f99) |
+
+**[See every disclosed finding →](https://gigioneggiando.github.io/argo/)**
+
+<sub>\* Measured across the 140 findings that reached an independent maintainer verdict — excludes
+findings still in triage, duplicates of already-known issues, and out-of-scope rejections, since
+none of those reflect whether the underlying security claim was correct. 127 were confirmed
+genuine, 13 were rejected as false positives.</sub>
+
+---
 
 Argo finds security vulnerabilities in **source code** by driving an LLM as the analyst — it reads
 the code the way a human auditor would, rather than matching rules against a graph. Point it at any
 codebase — a **local folder**, a private repo, or a public one — and it produces a reviewable
-vulnerability report. The core idea: start from reusable general prompts and **automatically enrich
-them** with target-specific context (stack, endpoints, docs, advisory history) — so every audit runs
-with tailored prompts instead of generic ones. It runs on whatever you have: **Claude Code**, the
-**Codex CLI** (OpenAI), or a **local open-source model**.
+vulnerability report. It runs **for free** if you point it at a local model (Ollama, LM Studio)
+instead of a paid backend.
 
-**Where it sits.** Argo is an **LLM-native SAST** — a complement and alternative to rule-based static
-analyzers (CodeQL, Semgrep): nothing to write (no queries, no rule packs), and it catches
+**Where it sits.** Argo is an **LLM-native SAST** — a complement and alternative to rule-based
+static analyzers (CodeQL, Semgrep): nothing to write (no queries, no rule packs), and it catches
 logic/authorization bugs that fixed patterns miss — at the cost of being *probabilistic* rather than
 exhaustive (see [design-decisions](docs/design-decisions.md)). It is **static by design** — it never
 executes the target (a hard guardrail), so it is *not* a DAST, fuzzer, or symbolic executor.
-**Bug-bounty triage is one specialized mode** (scope/RoE ingest, submission drafts, cross-run
-resubmission tracking), not the whole tool — see [Two modes](#-two-modes-general-audit-and-bug-bounty).
+**Bug-bounty triage is one specialized mode**, not the whole tool — see
+[Two modes](#-two-modes-general-audit-and-bug-bounty).
 
-- 🔎 **Threat-informed audit** — opt-out Stage-0 web OSINT (CVEs, advisories, history) feeds recon.
-- 🧠 **Archetype-driven prompts** — classifies the software, then writes custom audit prompts for it.
-- 🧭 **Reads for intent, not just syntax** — recon extracts named security invariants (what the code is
-  *supposed* to do, and how to check it) before the audit starts, so the hunt is closed-ended
-  verification against real intended behavior, not pattern-guessing that mistakes business logic for a bug.
-- 🛡️ **Adversarial validation** — a second model tries to *refute* each finding before it survives.
-- 🌐 **Docs + history corroboration** — opt-out cross-check of each finding against the project's own
-  docs, VCS history, issue tracker, PRs, and security advisories — catches "already fixed" and
-  "already reported" before it reaches you, not just "documented by design".
-- 🎯 **Design-aware & impact-disciplined** — inject the vendor's accepted-by-design behaviors (`--accepted-risks`) + an anti-over-claim rule (no reflexive IMDS/SSRF escalation) so intended behavior isn't reported and impact isn't inflated.
-- 🔌 **Multi-backend** — Claude / Codex / OpenAI / local-OSS, same pipeline (see [docs/backends.md](docs/backends.md)).
-- 🩹 **Opt-in remediation** — proposes a patch per finding and **verifies it compiles** on an isolated copy.
-- 💬 **Interrogation chat** — ask *"why didn't you find X?"* with full context ([worked example](docs/chat-example.md)).
-- 📊 **Benchmarks & costs** — precision/recall harness + observed cost analytics.
-- 🚫 **Detection-only, read-only, never live** — guardrails enforced in code, not just prompts.
+- 🩹 **Finds it, then proves it** — opt-in remediation proposes a patch per finding and **verifies it
+  compiles** on an isolated copy; opt-in runtime/live verification and ASan PoC generation back a
+  finding with a real, reproducible crash trace or HTTP proof, not just a claim.
+- 🛡️ **Built not to lie to you** — a second model tries to *refute* every finding, it's cross-checked
+  against the project's own docs and commit history, and one independent session re-derives each
+  survivor from source before anything reaches you. Uncertain stays flagged, never silently dropped.
+- 🧭 **Reads for intent, not just syntax** — recon extracts the security invariants the code is
+  *supposed* to hold before the audit starts, turning the hunt into closed-ended verification
+  instead of pattern-guessing that mistakes business logic for a bug.
+- 🔎 **Threat-informed** — opt-out web OSINT (CVEs, advisories, history) feeds every audit.
+- 🔌 **Multi-backend, including fully free** — Claude Code, Codex, or a **local open-source model**
+  (Qwen, DeepSeek via Ollama/LM Studio) — same pipeline, your choice of cost.
+- 💬 **Interrogation chat** — ask *"why didn't you find X?"* and get a real re-validation, not a
+  chatty answer ([worked example](docs/chat-example.md)).
+- 🚫 **Detection-only, read-only, never live by default** — guardrails enforced in code, not just
+  prompts.
 
 ![End-to-end pipeline flow](docs/diagrams/pipeline_flow.svg)
 
@@ -46,44 +68,23 @@ resubmission tracking), not the whole tool — see [Two modes](#-two-modes-gener
 
 ## 🕵️ It works like an expert reviewer, not a linter
 
-This is the part that's easy to oversell, so here's the honest version: Argo isn't a claim that
-expert judgment is unnecessary — every practice below is borrowed directly from how a careful human
-security researcher actually works, and a human still decides what gets reported. What it does claim
-is narrower, and we think it's true: it follows that discipline **consistently, on every run**, so
-what reaches you has already been through a first pass of the scrutiny an experienced reviewer would
-apply — not raw model output.
+This is easy to oversell, so here's the honest version: Argo isn't a claim that expert judgment is
+unnecessary — every practice below is borrowed from how a careful human security researcher
+actually works, and a human still decides what gets reported. What it claims is narrower: it
+follows that discipline **consistently, on every run**, so what reaches you has already been
+through a first pass of the scrutiny an experienced reviewer would apply, not raw model output.
 
-Concretely, this is not "an AI that greps for bugs":
-
-- **It works out what the code is supposed to do before it looks for what's wrong.** Recon extracts
-  named security invariants — *"this property must hold, here, and here's how to check it"* — and the
-  correct baseline pattern to diff variants against, before the audit starts. That turns the hunt into
-  **closed-ended verification** against the software's actual intended behavior, instead of
-  open-ended pattern guessing that flags normal business logic as a bug.
-- **It knows where to look.** Recon classifies what kind of software it's reviewing (web/API, CMS,
-  library/SDK, CLI, agent/LLM, …) and threat-informs itself with the project's own public CVE and
-  advisory history before writing a single audit prompt — the triage step an experienced auditor does
-  before opening the first file, instead of giving every line equal attention.
-- **It goes after the crown jewels, not noise.** A completeness-critic pass re-audits each area for
-  what a first read missed; a second, adversarial model then actively tries to *break* every finding
-  before it's allowed to survive — the same self-skepticism a careful reviewer applies to their own
-  draft before sending it.
-- **It checks whether you already know.** Before a finding reaches you, it's cross-checked against the
-  project's own documentation, its VCS history, and its issue tracker, PRs, and published advisories —
-  specifically to catch the two things that make a security report look amateur: flagging something
-  the maintainers already fixed, or flagging a documented, intentional design decision as if it were a
-  bug.
-- **It says "I don't know" instead of guessing.** A genuinely uncertain finding is kept as
-  `needs_runtime_verification` with a concrete open question attached — never silently dropped, and
-  never force-labeled "confirmed" just to look more complete. See a
-  [real, unedited transcript](docs/chat-example.md) of it correcting its own false positive and
-  admitting a false negative, mid-conversation.
+It works out what the code is *supposed* to do before it looks for what's wrong, classifies the
+software and threat-informs itself before writing a single audit prompt, re-audits each area for
+what a first read missed, then actively tries to break every finding before it's allowed to
+survive. A genuinely uncertain finding says so — kept with a concrete open question attached, never
+force-labeled "confirmed" just to look complete. See a
+[real, unedited transcript](docs/chat-example.md) of it correcting its own false positive and
+admitting a false negative, mid-conversation.
 
 None of this makes Argo infallible — it's a probabilistic tool, and says so throughout these docs
-(see [design-decisions.md](docs/design-decisions.md)). It means the floor is higher than "an LLM was
-asked to find bugs": what you're reviewing has already been triaged, self-critiqued, and fact-checked
-against public reality once. See it working on real, unmodified open-source code, not a curated demo:
-**[live findings](https://gigioneggiando.github.io/argo/)**.
+(see [design-decisions.md](docs/design-decisions.md)). See it working on real, unmodified
+open-source code, not a curated demo: **[live findings](https://gigioneggiando.github.io/argo/)**.
 
 ---
 
@@ -123,39 +124,6 @@ CTFs, or research. Three constraints are enforced in the orchestrator, not left 
 Additionally, prohibited techniques declared in scope (e.g. "no DoS") are propagated into every
 generated prompt, and prompt rendering fails if they are missing (re-inserted verbatim if a model
 paraphrases them — see [guardrails](docs/guardrails.md)).
-
----
-
-## 🧩 The assets (the reusable core)
-
-The security logic lives in the prompts; the orchestrator is only the glue that sequences them.
-
-| File | Role |
-|---|---|
-| `00_recon_synthesis_meta_prompt.md` | Stage 2. Profiles the repo, reconciles it with scope, and **generates** the complementary custom prompts. This is where general-to-detailed enrichment happens. |
-| `01_audit_prompt_template.md.j2` | Jinja skeleton every generated prompt conforms to. Fixed parts (role, finding format, rules of engagement, anti-false-positive constraints) never change; `{{ }}` slots carry target-specific content. |
-| `02_adversarial_validation_prompt.md` | Stage 4. For each finding it opens a fresh context and tries to **break it**. Only findings that survive get promoted. |
-| `09_deep_verify_prompt.md` | Stage VERIFY (opt-in). For each surviving finding, one full session re-derives it from the actual source and cross-checks it against every other survivor — split/merge/correct. |
-| `scope_schema.json` | Structure of scope/rules. Authoritative input to every stage and the final findings filter. |
-| `findings_schema.json` | Normalized findings format, for dedup and validation. |
-| `BUILD_SPEC.md` | Specification to hand to a coding agent to build the orchestrator around the assets. |
-
----
-
-## ✨ How enrichment works (Stage 2)
-
-This is the heart of the design. Three things converge — the reusable assets (always the same),
-`scope.json` with your links and rules, and the repo recon (stack, endpoints, CVE history) — and
-out come the complementary custom prompts for that single scan.
-
-![Prompt enrichment: general to custom](docs/diagrams/prompt_enrichment.svg)
-
-The split is **archetype-driven**: Stage 2 first classifies what kind of software the target is
-(web/API, CMS, plugin/extension, library/SDK, CLI, agent/LLM, mobile, data/ML pipeline, …) and
-chooses the prompt partition that fits — typically 3 complementary prompts, always including one
-architecture-led whole-system prompt — instead of a fixed web-app split. See
-[docs/prompt-synthesis.md](docs/prompt-synthesis.md) for how the prompt maker works and how to
-change it safely.
 
 ---
 
@@ -218,46 +186,25 @@ Run:
 argo ingest --brief brief.md --links links.txt --repo https://github.com/acme/acme-cms
 ```
 
-Resulting `scope.json`:
-```json
-{
-  "program_name": "ACME CMS",
-  "program_brief_raw": "<contents of brief.md>",
-  "in_scope": [{ "asset": "acme/acme-cms", "type": "source_repo" }],
-  "out_of_scope": ["*.staging.acme.com", "third-party plugins"],
-  "prohibited_techniques": ["no DoS / volumetric", "no social engineering", "max 10 req/s live"],
-  "reference_links": ["https://acme.com", "https://docs.acme.com", "https://acme.com/security", "https://acme.com/security/advisories"]
-}
-```
-
-Stage 2 takes `reference_links` and injects them at the top of every custom prompt, so the
-prompts start out already knowing where to read docs and advisories.
+Stage 2 takes the links from scope and injects them at the top of every custom prompt, so the
+prompts start out already knowing where to read docs and advisories. Full `scope.json` shape and
+every field: [docs/architecture.md](docs/architecture.md).
 
 ---
 
 ## ⚡ Usage
 
 ```
-argo ingest   --brief BRIEF --links LINKS --repo PATH_OR_URL   # Stage 1
-argo recon    --run RUN_ID                                     # Stage 2
-argo run      --run RUN_ID                                     # Stage 3
-argo validate --run RUN_ID                                     # Stage 4
-argo verify   --run RUN_ID                                     # Stage VERIFY (opt-in, deep re-derivation)
-argo asan-poc --run RUN_ID                                     # Stage ASAN_POC (opt-in, C/C++ crash traces)
-argo report   --run RUN_ID                                     # Stage 5
-argo second-opinion --run RUN_ID --passes 2                    # extra blind passes merged in (opt-in, standalone)
 argo pipeline --brief ... --links ... --repo ...               # 1-5, stops before submission
 argo pipeline --brief ... --repo ... --verify                  # + deep-verify before reporting
 argo pipeline --brief ... --repo ... --verify --asan-poc        # + real ASan crash traces for C/C++ survivors
 argo pipeline --brief ... --repo ... --second-opinion 1         # + one independent blind re-audit merged in
-argo pipeline --brief ... --repo ... --second-opinion 1 --second-opinion-backend codex  # cross-engine diversity
 argo pipeline --repo ./my-code                                 # 🔐 local/personal review — NO brief, NO URL
 ```
 
 **Auditing your own / private local code?** Omit `--brief` and point `--repo` at a **local folder**
-(it does not need to be a git repo, and is **never pushed anywhere** — the repo is mounted read-only).
-Argo synthesizes a minimal **source-only** scope from the folder (zero-token ingest, web research
-auto-off) and audits it. Note the analysis itself: a **cloud backend** (Claude / Codex) sends the
+(it does not need to be a git repo, and is **never pushed anywhere**). Argo synthesizes a minimal
+**source-only** scope from the folder and audits it. A **cloud backend** (Claude / Codex) sends the
 source to that provider's API to analyze it — only a **local / OSS model** (`--codex-oss`) keeps
 everything **fully on-device**.
 
@@ -271,11 +218,9 @@ Low-cost modes:
 ```
 argo pipeline ... --runner mock   # exercises the whole glue with fixtures, zero tokens
 argo pipeline ... --dry-run       # runs ingest+recon, shows generated prompts, then STOPS
-argo pipeline ... --no-research   # skip the Stage-0 web OSINT (fully offline)
 ```
 
-`--dry-run` is the prompt-quality feedback loop: it lets you eyeball the custom prompts before
-paying to run them.
+Every command, every flag, with more examples: **[docs/cli-reference.md](docs/cli-reference.md)**.
 
 ---
 
@@ -293,231 +238,53 @@ panel. See [docs/ui.md](docs/ui.md) and [docs/api.md](docs/api.md).
 
 ---
 
-## 🔬 The stages in detail
+## 🔬 The pipeline, stage by stage
 
-**1 — Ingest.** Parses the brief into `scope.json`, validated against `scope_schema.json`. If the
-program forbids automation, raises a flag that forbids any live interaction for the whole run.
-Clones/copies the repo into the run dir, read-only. `--accepted-risks FILE` records the vendor's
-**intended / accepted-by-design behaviors** (their threat model / known-limitations) into the scope,
-to be injected downstream so those behaviors are not re-reported as bugs.
+Each stage reads the previous one's output and writes its own — full detail, data flow, and the
+`AgentRunner` abstraction in **[docs/architecture.md](docs/architecture.md)**.
 
-**Design context + impact discipline** *(cross-cutting, always on)*. Every audit prompt (and the
-validate/corroborate/verify prompts) carries an injected block that (a) enforces **impact discipline** —
-report *proven* impact, not reflexive escalation, e.g. don't assert cloud-metadata/IMDS reachability
-for an SSRF without evidence, and treat "an admin can do an admin thing" as by design — and (b) when
-`--accepted-risks` is given, lists those behaviors so the model doesn't raise them. This attacks the
-two hardest false-positive modes directly at the source, before a finding is even written.
-
-**0 — Research** *(opt-out, one of two networked stages)*. From the brief, links, and program name it
-does **public web OSINT** (CVEs, advisories, the project's security history) and writes
-`research_brief.md` + `threat_intel.json`, injected into recon so the audit is threat-targeted. Never
-touches the program's live in-scope hosts; `--no-research` keeps the run fully offline.
-
-**2 — Recon + synthesis.** Runs `00_recon_synthesis_meta_prompt.md` with read access to the repo.
-Produces `repo_profile.json`, the complementary custom prompts, `synthesis_notes.md`, and
-**`ground_truth.json`** — a deep extraction (per focus) of security **invariants**,
-**baseline-correct references** to diff siblings against, the enumerated **variant families**, and
-target-specific **false-positive carve-outs**. Baking this into the prompts turns the audit from
-open-ended hunting into closed-ended verification (the main precision + depth lever).
-
-**3 — Audit.** For each prompt, a separate agent session in an isolated working dir, repo
-read-only. Each session emits findings JSON (validated against `findings_schema.json`) and a
-`VARIANT_HUNT_LOG` (one row per variant-family member). A **completeness-critic** re-pass
-(`--critic-passes`, default 1) then re-audits each focus for what was missed, looping until dry. A
-finding that drifts off-schema is **repaired and kept** (flagged), never silently dropped.
-
-**SCA — Software-composition analysis** *(opt-out, between audit and validate)*. Reads dependency
-manifests and flags pinned versions with known advisories as a `dependencies` focus. `--no-sca` or
-a repo with no manifests skips it.
-
-**SECOND-OPINION — Blind re-audit** *(opt-in, between SCA and validate; default off)*. Runs `--second-
-opinion N` additional, fully independent recon+audit passes over the same already-ingested scope/repo
-— each in its own isolated run directory, so it's genuinely blind to the primary pass's findings —
-then merges their raw findings in before validate runs. This is the pipeline form of a manual
-methodology used on real disclosures (fastjson2, open62541): a single LLM audit is one noisy sample
-of what a careful reader would find, and an independent second pass (optionally on a different
-backend via `--second-opinion-backend`, e.g. Claude for a Codex primary run) both recovers findings
-the first pass missed and, when it independently converges on the same bug, produces a real
-corroboration signal — surfaced in the report as "independently confirmed by N blind passes." A
-failed pass is skipped, never aborts the run. Needs almost no new matching logic: validate's existing
-structural + semantic dedup already collapses cross-pass duplicates the same way it collapses
-cross-focus ones within a single pass.
-
-**4 — Validate.** Merges findings, computes `dedup_key = sha1(normalize(file + line + cwe))` and
-collapses duplicates. For each survivor, runs `02_adversarial_validation_prompt.md` in a fresh
-context — now **ground-truth-aware** (the carve-outs + baseline-correct refs are injected).
-**Downgrade-don't-delete:** `refuted` is reserved for findings provably contradicted by code (or
-matching a carve-out); anything merely uncertain is **kept** as `needs_runtime_verification` with a
-concrete question. Drops `out_of_scope`; keeps `confirmed` and `needs_runtime_verification`.
-
-**CORROBORATE — Docs + history cross-check** *(opt-out, networked; after validate)*. For each
-surviving finding, cross-checks it against the project's **own documentation** and the source repo's
-**VCS history** (commits, releases, advisories) over public web OSINT — using `--docs-url`/scope
-links + the repo URL if given, else searching for them. A finding the docs describe as **intended**
-is downgraded to `design_accepted` (kept, flagged); one already **patched in a newer commit** is
-moved to `fixed_upstream` (kept in a report appendix, never silently deleted); the rest stay
-`corroborated`. Best-effort and never touches the live in-scope hosts; `--no-corroborate` skips it.
-This is the automated form of the two false-positive modes vendors push back on most: "already
-fixed" and "documented by design".
-
-**VERIFY — Deep verify** *(opt-in, offline; after corroborate; default off)*. The final, deepest
-check: unlike validate (adversarial but deliberately judges each finding in ISOLATION, batched,
-excerpt-budgeted) and corroborate (networked but never opens the repo), deep-verify runs ONE full
-agentic session per surviving finding — no batching, no excerpt budget, full `Read`/`Grep`/`Glob`
-access to the actual repo — and independently **re-derives** each finding from the source, then
-reasons **across the whole survivor set**. This catches what per-finding isolation structurally
-cannot: a finding that's actually ≥2 distinct triggerable bugs (`split`, replaced by independent
-sub-findings), two findings sharing one root cause (`merged`, folded into the other), or a finding
-whose mechanism is real but a stated fact is wrong (`corrected`, kept with the fix noted). Every
-verdict (even `reconfirmed`) requires an `independent_derivation` transcript — the file:line trail
-actually walked — so the pass is auditable, not just trusted. Downgrade-don't-delete still applies:
-only `refuted` drops a finding, `merged`/`split` originals are kept in report appendices. Off by
-default (the most expensive annotation stage); enable with `--verify` on `argo pipeline` or run
-`argo verify --run RUN_ID` standalone.
-
-**ASAN_POC — AddressSanitizer PoC generation** *(opt-in, sandboxed, C/C++ only; after verify;
-default off)*. For each already-verified memory-safety survivor, an offline session writes a
-**minimal, single-translation-unit harness** that `#include`s the real vulnerable source directly
-(never reimplements it) and compiles standalone — deliberately narrow, no attempt to drive an
-arbitrary third-party CMake/Autotools/Meson build. A **fixed, non-model** step then compiles it
-with `clang -fsanitize=address,undefined` and runs it inside an egress-blocked (`--network=none`)
-Docker container; a plain regex reads whether a sanitizer actually reported an error — never an LLM
-judgment call. `confirmed` (real sanitizer match) / `not_reproduced` (clean exit — does **not**
-refute the finding) / `crashed_no_sanitizer_output` / `not_attempted` (couldn't isolate/compile,
-reason logged). Best-effort per finding, needs Docker; enable with `--asan-poc` on `argo pipeline`
-or run `argo asan-poc --run RUN_ID` standalone.
-
-**RUNTIME — Runtime verification** *(opt-in, sandboxed; default off)*. Builds the OSS target from
-the cloned source into an **ephemeral, egress-blocked, loopback-only** container (`--network=none`)
-and probes **only that local instance** with HTTP PoCs to confirm/refute findings — never the
-program's live hosts (same trust model as the Phase-6 isolated build). Read-only probes by default,
-anti-DoS caps, no model execution primitive. Needs Docker + a launcher recipe; gracefully skips
-otherwise. Full safety design in [docs/runtime-verification-study.md](docs/runtime-verification-study.md).
-
-**5 — Report.** Produces `REPORT.md` (summary, findings sorted by validated severity then
-confidence, "fix first" ordering, residual unknowns) and one DRAFT submission per confirmed
-finding. Appends every finding to the SQLite ledger.
-
----
-
-## 📦 Artifact capture
-
-**Files are the source of truth**, the manifest is only an index. Each Claude session writes its
-artifacts as separate files into its own scratch dir (`repo_profile.json`, one `.md` per prompt,
-`SECURITY_FINDINGS__<focus>.json`, validation verdicts), each conforming to its schema. The final
-message returns a small manifest indexing them. The orchestrator treats the files as
-authoritative; if the manifest is missing or the session dies, it falls back to globbing the
-scratch dir (partial recovery). Claude Code's `--output-format json` is used only for run metadata
-(session id, cost, stop reason), never for the artifacts.
-
-Reason: deep-audit findings and full prompts are too large to fit one stdout JSON without risking
-truncation (which would silently drop findings); files survive long-session crashes and map
-cleanly to the heterogeneous artifact types.
+| Stage | What it does |
+|---|---|
+| 0 Research *(opt-out)* | Web OSINT — CVEs, advisories, project history — feeds recon before audit starts. |
+| 1 Ingest | Parses the brief into `scope.json`; clones the repo read-only. |
+| 2 Recon + synthesis | Classifies the software, extracts security invariants + baseline-correct references, writes custom audit prompts. |
+| 3 Audit | Per-prompt agent sessions emit findings; a completeness-critic re-pass catches what a first read missed. |
+| SCA *(opt-out)* | Flags dependency-pinned versions with known advisories. |
+| Second opinion *(opt-in)* | N independent blind recon+audit passes, merged in before validate. |
+| 4 Validate | Dedup, then adversarial validation — a fresh session tries to refute each survivor. Downgrade-don't-delete: only provable contradictions get dropped. |
+| Corroborate *(opt-out)* | Cross-checks survivors against the project's own docs and VCS history — catches "already fixed" and "documented by design". |
+| Verify *(opt-in, deep)* | One full independent session per survivor re-derives it from source and reasons across the whole set — split / merge / correct. |
+| ASan PoC *(opt-in, C/C++)* | Model writes a harness; a **fixed, non-model** step compiles and runs it under AddressSanitizer in an isolated container — a real sanitizer crash trace, not a judgment call. |
+| Runtime *(opt-in, sandboxed)* | Builds the target into an egress-blocked container and confirms findings with a real HTTP PoC — never the program's live hosts. |
+| 5 Report | `REPORT.md`, sorted by verified severity, plus one DRAFT submission per confirmed finding. |
 
 ---
 
 ## 🔌 Backends & model strategy
 
-**Backends.** Same pipeline, swappable engine — pick what you have:
-`--runner headless` (Claude Code) · `--runner codex` (Codex CLI → OpenAI, or `--codex-oss
---codex-local-provider ollama|lmstudio` for **local open-source** models like Qwen/DeepSeek) ·
-`--runner mock` (free fixtures). The guardrails are enforced per backend (Claude tool denylists,
-Codex OS sandbox); cost is authoritative for Claude and token-estimated for Codex. Full details in
-**[docs/backends.md](docs/backends.md)**.
-
-**Resilience — multi-account & multi-backend fallback.** Backends and accounts chain transparently:
-when one hits a **retryable failure** (session/rate limit, a timeout, or a classified Codex
-moderation-flag/credits-exhaustion signature) the same call is retried on the next (a per-run
-circuit breaker disables the walled one, for a cooldown that's longer for a confirmed dead-account
-signal and includes a real delay before retrying the *same* backend again after a moderation flag;
-a non-retryable error propagates immediately). On top of that, a stage that still fails after
-exhausting its whole backend chain gets a few bounded, automatic in-process retries before the CLI
-gives up and tells you to `argo resume` — many transient failures now resolve themselves without
-you needing to notice and re-invoke anything. Since limits are **per-account**, two logged-in
-Claude accounts double your capacity before falling through to Codex:
-
-```bash
-# account A -> account B -> Codex, all transparent on a 429
-python -m argo.cli pipeline --repo <url> --calibration \
-  --claude-accounts ~/.claude,~/.claude-b --fallback codex
-# set up the 2nd account once:  CLAUDE_CONFIG_DIR=~/.claude-b claude login
-```
-Codex multi-account works the same way (`--codex-accounts ~/.codex,~/.codex-b`, via `CODEX_HOME`).
-So a long Opus run that used to wall on the Claude limit mid-`validate` now self-heals to the next
-account/backend instead of degrading.
-
-Per-stage Claude defaults (overridable per-run; Codex uses one model for all stages):
-
-```
-ingest      -> sonnet-4-6   (cheap extraction; never Haiku — misreading scope/RoE costs a lot)
-recon       -> opus-4-8     (highest-leverage step: the whole audit's quality depends on it)
-audit P1..Pn-> sonnet-4-6   (parallel; see note)
-validate    -> opus-4-8     (cuts false positives)
-report      -> sonnet-4-6
-```
-
-Key concept: validation (Opus) removes **false positives**, but does **not recover false
-negatives** — bugs the audit model never surfaced are gone. So the audit model is the only lever
-on the missed-bug rate, which is the failure that matters for vulnerability detection.
-
-**Model landscape (why the backend is swappable).** Argo deliberately keeps the model behind the
-`AgentRunner` interface, because detection quality tracks the model. The frontier is moving fast and
-toward security specifically: Anthropic's **Claude Mythos 5** was described as having the strongest
-cybersecurity capability of any model — strong enough that the general-use **Fable 5** ships with a
-classifier that *routes* cybersecurity (and bio/chem) requests to Claude Opus 4.8 instead, and
-direct access to Mythos/Fable 5 was later restricted under a US export-control directive
-([Anthropic](https://www.anthropic.com/news/claude-fable-5-mythos-5),
-[red.anthropic.com](https://red.anthropic.com/2026/mythos-preview/)). The takeaway for Argo: as
-security-specialized models become accessible, the swappable backend means Argo gets better by
-pointing at a stronger engine — no pipeline changes. Today it runs on the generally-available
-backends above.
-
-Calibration phase (first ~5 programs): override `audit -> opus-4-8`. While the prompts are
-unproven, you don't want to confound "weak prompt" with "weak model" when diagnosing misses. Once
-a class of targets reliably yields good findings, drop to Sonnet to scale. Per-target rule
-thereafter: high expected bounty/severity -> audit on Opus; broad low-value sweeps -> Sonnet.
-
----
-
-## 🧪 Development and testing
-
-Recommended order: build the `MockClaudeRunner` + tests first, then the real headless runner. That
-way, when you wire in the real model, the glue is already verified and any remaining problem comes
-from the Claude Code interaction, not your logic.
-
-Mock fixtures should exercise the **failure paths**, not the happy path: an out-of-scope finding
-(scope filter), the same finding from two focuses (dedup), a refuted finding (drop), a missing
-manifest (glob fallback), a session that died mid-write (partial recovery), an oversized findings
-JSON (no truncation assumptions). Also keep one "recorded real run" fixture that replays the
-artifacts of a genuine Opus run, so the mock stays realistic and catches output-shape drift.
-
-Tests to ship: schema conformance at every stage boundary, a golden-file test for `REPORT.md`, and
-regression tests on dedup + validation filtering.
-
----
-
-## 🌐 Live targets
-
-You mostly work on source, but some programs include live assets. There, static review produces
-**hypotheses**, not proof of exploitability. The pipeline never touches a live host: for each
-finding it emits a `live_verification_plan` (safe, in-scope, non-DoS steps) that you verify
-manually against the instance, inside the program rules.
+Same pipeline, swappable engine — pick what you have: `--runner headless` (Claude Code) ·
+`--runner codex` (Codex CLI → OpenAI, or `--codex-oss --codex-local-provider ollama|lmstudio` for
+**local open-source models** like Qwen/DeepSeek, fully free and on-device) · `--runner mock` (free
+fixtures). Backends and accounts chain transparently on a rate limit or transient failure, so a long
+run self-heals instead of stalling. Full model-per-stage defaults, the resilience/fallback design,
+and the cross-model study: **[docs/backends.md](docs/backends.md)**.
 
 ---
 
 ## 💡 Operational tips
 
 - **A run that stops (crash, Ctrl+C, a rate limit) is not lost.** Every stage writes its output
-  atomically, so `argo resume RUN_ID` continues from the first unfinished stage — no re-ingest, no
-  re-paying for stages already done. The CLI prints the exact command when a run stops. Details:
+  atomically, so `argo resume RUN_ID` continues from the first unfinished stage. Details:
   [cli-reference.md § Recovering a stopped run](docs/cli-reference.md#recovering-a-stopped-run).
 - Keep prompts under git and record which version each run used: you can A/B test them and see
   which produce accepted findings.
 - The SQLite ledger avoids re-reporting the same bug across runs/programs and tracks your hit rate.
-- Log the cost of every LLM call (useful on the Max plan).
 - The most useful metric to watch is the ratio of validation-confirmed findings to triager-accepted
   findings: if they diverge, tune the validation prompt.
 - Always check whether a given program permits automated/AI tooling before running it.
+
+Development setup, the mock-runner-first testing approach, and what the suite covers:
+**[docs/testing.md](docs/testing.md)** and **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ---
 
@@ -537,9 +304,10 @@ This README is the conceptual overview. Deeper, implementation-level docs live i
 | [docs/api.md](docs/api.md) | The HTTP API (`server/`) — backend for the web UI: endpoints, run lifecycle, live status/SSE, artifact whitelist |
 | [docs/ui.md](docs/ui.md) | The web UI (`webapp/`) — `python -m argo.cli serve`, the no-build stack, the views |
 | [docs/chat-example.md](docs/chat-example.md) | 💬 The interrogation chat — a real worked transcript (grounded explanation, false-positive self-correction, honest false negatives) |
-| [docs/roadmap.md](docs/roadmap.md) | Planned UI + advanced features: per-feature analysis, phased build order, todo list (Phase 0 done) |
+| [docs/roadmap.md](docs/roadmap.md) | Planned UI + advanced features: per-feature analysis, phased build order, todo list |
 | [docs/configuration.md](docs/configuration.md) | `PipelineConfig` reference, per-stage models, budgets/caps |
 | [docs/testing.md](docs/testing.md) | How to run the suite, what it covers, mock vs. headless |
+| [docs/releasing.md](docs/releasing.md) | The versioning convention and how a release is cut |
 
 ## 📄 License
 
@@ -547,4 +315,3 @@ Apache License 2.0 — see [LICENSE](LICENSE). Argo is **detection-only** and in
 **authorized** security testing (bug-bounty programs with safe harbor, your own code, CTFs, or
 research). You are responsible for staying within the scope and rules of engagement of any program
 you point it at.
-


### PR DESCRIPTION
## Summary
- Add a proof table of real, disclosed findings near the top (ordered by severity, then stars): ds4, moquette, PocketBase, LiveKit, coturn.
- Add a measured 91% real-world accuracy figure (127/140 findings that reached an independent maintainer verdict), with methodology noted.
- Reorder feature bullets to surface remediation/PoC-verification and free local-model support, previously buried.
- Trim the long per-stage and per-backend prose sections down to short tables/pointers into `docs/`, which already cover that depth (551 -> 314 lines).

## Test plan
- [x] Verified every doc/link/image referenced in the new README exists on disk.
- [x] Checked heading structure renders as a clean outline (no orphaned levels).