### PR TITLE
chore: gitignore more one-off campaign scratch naming patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,16 @@ chatplugin/
 /run_*.log
 /finish_*.py
 /finish_*.log
+/resume_*.py
+/resume_*.log
+/retry_*.py
+/retry_*.log
+/finalize_*.py
+/finalize_*.log
+/codex_*.log
+/CODEX_TASK_*.md
+/authentik_run.log
+/authentik_resume.log
 /*_build.log
 /*_tail.log
 /*_tail.py


### PR DESCRIPTION
## Summary
- Extend `.gitignore`'s local-scratch section to also cover `resume_*`, `retry_*`, `finalize_*`, `codex_*.log`, `CODEX_TASK_*.md`, and the two `authentik_*.log` files — these fell outside the existing `run_*`/`finish_*` rules and showed up as untracked clutter in `git status`.
- No tracked files changed besides `.gitignore` itself (the ~80 scratch files removed locally were never tracked).

## Test plan
- [x] Confirmed every referenced finding (CEN-*, UMB3-*, authentik, open62541, navidrome) already exists in Fleece's registry before deleting the local scratch.
- [x] `git status` is clean after the change.