### PR TITLE
verify: make deep-verify resumable by default, add --only (release v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ particular while the version stays `0.y.z`.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-17
+
+### Added
+
+- `argo verify` is now **resumable by default**: re-running it on a run that already has some
+  deep-verify verdicts skips findings that got a real answer and only re-attempts unverified or
+  infra-failure (`inconclusive`) ones — safe to re-invoke after a backend runs out of credits, a
+  rate limit, or a crash without re-spending on already-completed sessions.
+- `argo verify --only ID,ID` — force specific findings to (re-)verify regardless of their current
+  state, leaving every other survivor untouched (mirrors `fix --only`).
+
 ## [0.2.0] - 2026-08-14
 
 First formally tracked release. Argo has been under active development since 2026-06-18 (99

--- a/argo/__init__.py
+++ b/argo/__init__.py
@@ -14,4 +14,4 @@ Hard guardrails are enforced in code (not just in prompts):
   * every LLM call is logged (prompt hash, model, token cost).
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/argo/cli.py
+++ b/argo/cli.py
@@ -405,6 +405,12 @@ def verify(run: str = RunIdArg,
               None, "--max-findings",
               help="cap how many survivors get a deep-verify session (cost control); "
                    "omit to deep-verify every survivor"),
+          only: Optional[str] = typer.Option(
+              None, "--only",
+              help="comma-separated finding ids to (re-)verify; every other survivor is left "
+                   "completely untouched. Omit for the default resumable behavior: findings "
+                   "that already have a real verdict are skipped, only unverified or "
+                   "infra-failure-inconclusive ones get a session."),
           runner: str = RunnerOpt, audit_model: Optional[str] = AuditModelOpt,
           calibration: bool = CalibrationOpt, budget: Optional[float] = BudgetOpt,
           parallel: int = ParallelOpt, runs_dir: Path = RunsDirOpt, scenario: str = ScenarioOpt):
@@ -413,9 +419,12 @@ def verify(run: str = RunIdArg,
     the whole survivor set — catches what validate/corroborate's per-finding isolation cannot: a
     finding that is actually several distinct bugs (split), two findings sharing one root cause
     (merged), or a finding whose mechanism is real but a stated detail is wrong (corrected).
-    Offline, opt-in, best-effort. Rewrites validated_findings.json in place."""
+    Offline, opt-in, best-effort. Resumable by default (skips already-verified survivors) and
+    rewrites validated_findings.json in place."""
+    only_ids = frozenset(s.strip() for s in only.split(",") if s.strip()) if only else None
     cfg = _build_config(runner, audit_model, calibration, budget, parallel, runs_dir, scenario
-                        ).with_overrides(verify_enabled=True, verify_max_findings=max_findings)
+                        ).with_overrides(verify_enabled=True, verify_max_findings=max_findings,
+                                         verify_only=only_ids)
     ctx = build_context(cfg, run)
     path = do_verify(ctx)
     _emit({"run_id": run, "validated_findings": str(path)})

--- a/argo/config.py
+++ b/argo/config.py
@@ -237,6 +237,13 @@ class PipelineConfig:
     # (seen for real: 1-4M input tokens, $1-4 per session) - worth one retry before giving up on a
     # crash. 1 = no retry (legacy/cheap behavior).
     verify_max_attempts: int = 2
+    # Explicit finding-id scope for this invocation (mirrors `fix --only`). None = the default,
+    # resumable behavior: findings that already carry a real (non-infra-failure) verification are
+    # left untouched and only findings with no verification yet, or an infra-failure `inconclusive`
+    # from a prior interrupted run, get a session. When set, exactly these ids get a (re-)session
+    # regardless of their current state, and every other survivor is left completely untouched -
+    # for deliberately re-verifying specific findings without re-spending on the rest.
+    verify_only: frozenset[str] | None = None
 
     # --- Freshness check (opt-in, networked git history check; informational only) -----------------
     # OFF by default. Late in the pipeline, check whether cited files were touched on the audited

--- a/argo/stages/deep_verify.py
+++ b/argo/stages/deep_verify.py
@@ -215,9 +215,28 @@ def run(ctx: RunContext) -> Path:
         _log("no surviving findings to deep-verify")
         return ctx.validated_findings_path
 
+    only = ctx.config.verify_only
+    if only is not None:
+        # Explicit scope: exactly these ids get a session; everyone else is untouched, whatever
+        # their current state (verified, unverified, or infra-failure) — the caller has decided.
+        candidates = [f for f in survivors if f.id in only]
+        untouched = [f for f in survivors if f.id not in only]
+    else:
+        # Default resumable behavior: a finding that already carries a real verdict (anything but
+        # an infra-failure inconclusive) from a prior invocation of this stage is done — re-running
+        # `argo verify` on the same run after a partial failure (credits ran out, a rate limit, a
+        # crash) should only re-spend on what didn't get a real answer last time, not everything.
+        candidates = [f for f in survivors
+                      if f.verification is None or _is_infra_failure(f.verification)]
+        untouched = [f for f in survivors
+                     if f.verification is not None and not _is_infra_failure(f.verification)]
+        if untouched:
+            _log(f"{len(untouched)} finding(s) already have a real deep-verify verdict, skipping "
+                 f"(use --only to force a specific finding to re-verify)")
+
     cap = ctx.config.verify_max_findings
-    eligible = survivors if cap is None else survivors[:cap]
-    beyond_cap_ids = {f.id for f in survivors[len(eligible):]}
+    eligible = candidates if cap is None else candidates[:cap]
+    beyond_cap_ids = {f.id for f in candidates[len(eligible):]}
 
     launch: list[Finding] = []
     for f in eligible:
@@ -228,7 +247,7 @@ def run(ctx: RunContext) -> Path:
             _log(f"budget reached; {len(eligible) - len(launch)} finding(s) left un-deep-verified ({exc})")
             break
     launched_ids = {f.id for f in launch}
-    skipped = [f for f in survivors if f.id not in launched_ids]
+    skipped = [f for f in candidates if f.id not in launched_ids]
 
     verdicts: dict[str, Verification] = {}
     if launch:
@@ -244,7 +263,7 @@ def run(ctx: RunContext) -> Path:
                   else "not deep-verified: per-run budget reached")
         verdicts[f.id] = Verification(verdict="inconclusive", rationale=reason)
 
-    kept: list[Finding] = []
+    kept: list[Finding] = list(untouched)
     split_originals: list[dict] = []
     merged_findings: list[dict] = []
     newly_dropped: list[dict] = []
@@ -252,7 +271,7 @@ def run(ctx: RunContext) -> Path:
     infra_failure = 0
     split_children_total = 0
 
-    for f in survivors:
+    for f in candidates:
         v = verdicts.get(f.id)
         if v is None:   # never launched and not in skipped (shouldn't happen, but never silently drop)
             kept.append(f)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,17 @@ of the same field/bytes, checking whether one plausibly runs earlier and could i
 reachability, and downgrading to `corrected` (not silently `reconfirmed`) when it does — the kind of
 cross-call-site reasoning validate/corroborate cannot do from an excerpt in isolation.
 
+**Deep verify is resumable by default** (added 2026-08-17, after a real run needed two manual
+re-invocations mid-campaign — a backend ran out of credits partway through, and the fallback
+backend then hit its own session limit). Each session is expensive enough (no excerpt budget, real
+runs have seen 1-4M input tokens / $1-4 per finding) that re-running `argo verify` on the same run
+after an interruption must not re-spend on findings that already got a real answer. A finding whose
+`verification` is either unset or an infra-failure `inconclusive` (a session crash, no output, a
+budget/cap cutoff — see `_is_infra_failure`) is treated as needing a session; anything else (
+`reconfirmed`/`corrected`/`split`/`merged`/`refuted`, or a genuine — not infra — `inconclusive`) is
+left completely untouched. `--only ID,ID` overrides this to force specific findings regardless of
+their state, mirroring `fix --only`.
+
 **ASan PoC generation: why V1 is deliberately narrow.** Across every C/C++ disclosure so far
 (nanomq, open62541, coturn) the single most time-consuming manual step has been hand-writing a
 minimal AddressSanitizer harness to turn a static finding into a real crash trace — the most

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ Everywhere below, `argo` ≡ `python -m argo.cli`.
 | `second-opinion` | SECOND-OPINION | **opt-in**, offline: run N additional, fully independent blind recon+audit passes over the already-ingested scope/repo (each in its own isolated `run_dir`), merge their findings in. `--passes N`, `--backend` to use a different runner for the extra passes (real cross-engine diversity). Re-run `validate` afterward to reconcile — its existing dedup already collapses cross-pass duplicates and records `corroborating_passes`; see [architecture.md](architecture.md#second-opinion-an-llm-audit-is-one-noisy-sample-not-the-answer) |
 | `validate` | 4 | dedup + adversarial validation (downgrade-don't-delete) → `validated_findings.json` |
 | `corroborate` | CORROBORATE | **opt-out**, networked: cross-check each finding against the project's **docs** + the repo's **VCS history** (commits/releases/advisories) over public web OSINT → downgrade documented-by-design, move already-fixed to a `fixed_upstream` appendix. Rewrites `validated_findings.json`. `--docs-url` to pin docs; never the live hosts |
-| `verify` | VERIFY | **opt-in**, offline: independently re-derive each surviving finding from the actual source (full repo access, one full session per finding, no batching, no excerpt budget) and reason across the whole survivor set → `corrected`/`split`/`merged`/`reconfirmed`/`refuted`/`inconclusive`. Rewrites `validated_findings.json`. `--max-findings` to cap cost; see [architecture.md](architecture.md#deep-verify-why-a-separate-stage-from-validate) |
+| `verify` | VERIFY | **opt-in**, offline: independently re-derive each surviving finding from the actual source (full repo access, one full session per finding, no batching, no excerpt budget) and reason across the whole survivor set → `corrected`/`split`/`merged`/`reconfirmed`/`refuted`/`inconclusive`. Rewrites `validated_findings.json`. **Resumable by default**: re-running it on the same run skips findings that already have a real verdict and only re-attempts unverified/infra-failure ones — safe to re-invoke after a rate limit or a backend running out of credits without re-spending on what already succeeded. `--only ID,ID` to force specific findings to (re-)verify regardless of their state, leaving everything else untouched; `--max-findings` to cap cost; see [architecture.md](architecture.md#deep-verify-why-a-separate-stage-from-validate) |
 | `asan-poc` | ASAN_POC | **opt-in**, sandboxed, **C/C++ only**: for each already-verified memory-safety survivor, an offline LLM writes a minimal single-file harness that `#include`s the real vulnerable source directly, then a FIXED (non-model) step compiles it with `clang -fsanitize=address,undefined` and runs it in an egress-blocked Docker container → per-finding `confirmed`/`not_reproduced`/`crashed_no_sanitizer_output`/`not_attempted`. Rewrites `validated_findings.json`; harness + notes + full output land in `runs/<id>/asan_poc/<finding_id>/`. `--max-findings` to cap cost. Needs Docker; see [architecture.md](architecture.md#asan-poc-generation-why-v1-is-deliberately-narrow) |
 | `runtime` | RUNTIME | **opt-in** sandboxed runtime verification: build the target in an egress-blocked, loopback-only container and probe ONLY the local instance (never live hosts) → `runtime_results.json`. See [runtime-verification-study.md](runtime-verification-study.md) |
 | `live` | LIVE | ⚠️ **opt-in, default off, AUTHORIZED USE ONLY.** Bounded **read-only** requests to the program's **in-scope** hosts to confirm findings. Requires `--i-have-authorization`; RoE-gated (automation/safe-harbor/prohibited), in-scope-only (out-of-scope/unknown blocked), capped + audit-logged. Uses a hand-written `runs/<id>/live_probe_plan.json` if present, else (L2) an **offline** LLM generates one from the validated findings (same gates apply) and interprets the results → `live_results.json` + `live_audit_log.jsonl` (+ a `validation.live` block on findings). See [guardrails §2c](guardrails.md#2c-the-opt-in-live-exception-the-live-stage-in-scope-hosts-only) |
@@ -49,6 +49,7 @@ argo report   --run RUN_ID
 argo pr-draft --run RUN_ID --finding FINDING_ID [--test-command "CMD"]
 argo pipeline --repo PATH_OR_URL [--brief BRIEF.txt] [--links LINKS.txt] [--commit SHA] [--dry-run] [--smoke]
 argo resume   RUN_ID [--wait] [--max-wait 12h]
+argo verify   --run RUN_ID [--only ID,ID] [--max-findings N]
 argo asan-poc --run RUN_ID [--max-findings N] [--asan-poc-image IMAGE]
 argo fix      --run RUN_ID [--no-verify] [--re-audit] [--docker IMAGE] [--build-cmd "CMD"] [--only ID,ID]
 argo bench    --suite DIR [--fixes] [--re-audit] [--parallel-cases N] [--ab-audit-model MODEL]
@@ -56,6 +57,12 @@ argo feedback [--program P --dedup K --accepted/--rejected [--run R] [--note ...
 argo quality  [--program P] [--runs-dir DIR]
 ```
 
+- **`argo verify` is safely re-invokable.** Each session costs real money (no excerpt budget,
+  seen up to $1-4/1-4M tokens per finding), so if a run gets interrupted partway (a backend runs
+  out of credits, a rate limit, a crash), just run `argo verify --run RUN_ID` again — findings that
+  already have a real verdict are left alone, only unverified/infra-failure ones get a new session.
+  Use `--only ID,ID` to force a re-verify of specific findings regardless of their current state
+  (e.g. after fixing something in the target that might change the answer).
 - `argo fix --re-audit` — after verifying a patch, re-audit the patched copy and report whether the
   vuln is still detected (`verify.re_audit.confirmed_fixed`; one extra model session per patch).
 - `argo bench --parallel-cases N` — run N labeled cases concurrently (corpora at scale);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argo-audit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Argo — AI source-static security-audit pipeline for bug-bounty programs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_deep_verify.py
+++ b/tests/test_deep_verify.py
@@ -214,6 +214,84 @@ def test_exhausts_retries_and_falls_back_to_inconclusive(env, make_scenario):
     assert "deep-verify session failed" in f1["verification"]["rationale"]
 
 
+# --------------------------------------------------------------------------- resumable / --only
+def _verify_call_count(ctx) -> int:
+    return sum(1 for l in (ctx.run_dir / "llm_log.jsonl").read_text(encoding="utf-8")
+               .strip().splitlines() if json.loads(l)["stage"] == "verify")
+
+
+def test_resumable_skips_already_verified_findings(env):
+    """Re-running deep-verify on a run that already has real verdicts must not re-spend on them —
+    this is what makes `argo verify` safely re-invokable after a partial failure (credits ran out,
+    a rate limit, a crash) without redoing every already-completed, expensive session."""
+    from argo.stages import deep_verify
+
+    ctx = env(verify_enabled=True)
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    calls_after_first_pass = _verify_call_count(ctx)
+    assert calls_after_first_pass == 3
+
+    deep_verify.run(ctx)  # second invocation, same run, no new fixtures set up
+    assert _verify_call_count(ctx) == calls_after_first_pass   # no new sessions launched
+    vf = _validated(ctx)
+    assert {f["id"] for f in vf["findings"]} == SURVIVORS
+    for f in vf["findings"]:
+        assert f["verification"]["verdict"] == "reconfirmed"    # unchanged from the first pass
+
+
+def test_resumable_retries_infra_failure_findings(env, make_scenario):
+    """The flip side of resumability: a finding that came out of a prior pass as an
+    infra-failure inconclusive (session crash, credits ran out mid-run) is NOT considered "done" —
+    it must get a real session on the next invocation, unlike a genuinely-answered finding."""
+    from argo.stages import deep_verify
+
+    fixtures_dir, scen = make_scenario(lambda d: _fail_once(d, "FULL-001"), name="resumeretry")
+    ctx = env(scen, fixtures_dir=fixtures_dir, verify_enabled=True, verify_max_attempts=1)
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    vf = _validated(ctx)
+    f1 = next(f for f in vf["findings"] if f["id"] == "FULL-001")
+    assert f1["verification"]["verdict"] == "inconclusive"
+    assert "deep-verify session failed" in f1["verification"]["rationale"]   # infra failure, not genuine
+
+    # The sentinel fails every fresh (non-retry) attempt by design (see MockClaudeRunner's own
+    # docstring) — remove it to simulate the transient problem being gone by the next invocation,
+    # then confirm the finding gets a real session again rather than being treated as already done.
+    (fixtures_dir / scen / "verify" / "FULL-001._fail_once").unlink()
+    deep_verify.run(ctx)
+    vf = _validated(ctx)
+    f1 = next(f for f in vf["findings"] if f["id"] == "FULL-001")
+    assert f1["verification"]["verdict"] == "reconfirmed"        # re-attempted and got a real verdict
+
+
+def test_only_scopes_to_specific_findings(env, make_scenario):
+    """--only (config verify_only) re-verifies exactly the given ids and leaves every other
+    survivor's existing verification completely untouched, regardless of its state."""
+    from argo.stages import deep_verify
+
+    ctx = env(verify_enabled=True)
+    run_pipeline(ctx, BRIEF, str(REPO), research_enabled=False)
+    for f in _validated(ctx)["findings"]:
+        assert f["verification"]["verdict"] == "reconfirmed"     # baseline from the first pass
+
+    fixtures_dir, scen = make_scenario(
+        lambda d: _verify_fixture(d, "FULL-001", {
+            "finding_id": "FULL-001", "verdict": "corrected",
+            "rationale": "re-derived on the targeted re-verify pass",
+            "independent_derivation": "opened src/api/search.py:42, re-traced the flow",
+            "corrections": "the sink is actually at line 44, not 42"}),
+        name="onlyscope")
+    ctx.runner.scenario_dir = fixtures_dir / scen   # mock runner bakes scenario_dir in at
+                                                     # construction; point it at the new fixtures
+    ctx.config = ctx.config.with_overrides(verify_only=frozenset({"FULL-001"}))
+
+    deep_verify.run(ctx)
+    vf = _validated(ctx)
+    kept = {f["id"]: f for f in vf["findings"]}
+    assert kept["FULL-001"]["verification"]["verdict"] == "corrected"          # re-verified
+    assert kept["AUTHZ-002"]["verification"]["verdict"] == "reconfirmed"       # untouched
+    assert kept["FULL-003"]["verification"]["verdict"] == "reconfirmed"        # untouched
+
+
 # --------------------------------------------------------------------------- guardrail
 def test_verify_is_offline_with_full_repo_access():
     assert session_policy("verify").network is False


### PR DESCRIPTION
## Summary
- `argo verify` re-launched a session for every survivor on every invocation, even ones that already had a real verdict — costly given deep-verify sessions have no excerpt budget (real runs have seen $1-4 / 1-4M tokens per finding).
- Discovered this the hard way today: a real campaign needed two manual re-invocations after one backend ran out of credits and the fallback then hit its own rate limit, each requiring a hand-written script to filter/merge the JSON around the stage's lack of resumability.
- Now: re-running `argo verify` on the same run skips findings that already carry a real (non-infra-failure) verification and only re-attempts unverified/infra-failure ones.
- New `--only ID,ID` flag forces specific findings to (re-)verify regardless of state, leaving everything else untouched — mirrors `fix --only`.
- This is additive (new flag, changed-but-backward-compatible default behavior for re-invocation) — release v0.3.0 per docs/releasing.md's MINOR criteria.

## Test plan
- [x] 3 new tests: default resume skips already-verified findings, infra-failure findings ARE re-attempted, `--only` scopes correctly and leaves everything else untouched
- [x] Full suite green: 389 passed, 2 skipped (pre-existing)