### PR TITLE
feat: add Gemini CLI backend (--runner gemini)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ particular while the version stays `0.y.z`.
 
 ## [Unreleased]
 
+### Added
+
+- **Gemini CLI backend** (`--runner gemini`): a third swappable engine alongside Claude Code and
+  Codex, tiered per stage like Claude (`gemini-3.1-pro` / `gemini-3.5-flash` / `gemini-3.1-flash-lite`
+  — see `DEFAULT_GEMINI_STAGE_MODELS`), fully composable into the existing fallback chain
+  (`--fallback`) and multi-account resilience machinery. Guardrails map onto Gemini's **Policy
+  Engine** (a named-tool denylist, the same dialect Claude uses), not `--sandbox`, which was found
+  to have a hard, unreliable Docker/Podman dependency during empirical verification against a real
+  `gemini` CLI install. `--gemini-model`, `--gemini-api-key`, `--gemini-accounts` CLI flags; matching
+  `RunConfig` fields on the HTTP API. See [docs/backends.md](docs/backends.md#gemini-specifics-runner--gemini).
+
 ## [0.3.0] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ executes the target (a hard guardrail), so it is *not* a DAST, fuzzer, or symbol
   *supposed* to hold before the audit starts, turning the hunt into closed-ended verification
   instead of pattern-guessing that mistakes business logic for a bug.
 - 🔎 **Threat-informed** — opt-out web OSINT (CVEs, advisories, history) feeds every audit.
-- 🔌 **Multi-backend, including fully free** — Claude Code, Codex, or a **local open-source model**
-  (Qwen, DeepSeek via Ollama/LM Studio) — same pipeline, your choice of cost.
+- 🔌 **Multi-backend, including fully free** — Claude Code, Codex, Gemini, or a **local open-source
+  model** (Qwen, DeepSeek via Ollama/LM Studio) — same pipeline, your choice of cost.
 - 💬 **Interrogation chat** — ask *"why didn't you find X?"* and get a real re-validation, not a
   chatty answer ([worked example](docs/chat-example.md)).
 - 🚫 **Detection-only, read-only, never live by default** — guardrails enforced in code, not just
@@ -133,7 +133,7 @@ paraphrases them — see [guardrails](docs/guardrails.md)).
 argo/
   cli.py
   models.py            # pydantic models for scope + findings
-  runner.py            # AgentRunner interface (Claude headless · Codex · mock)
+  runner.py            # AgentRunner interface (Claude headless · Codex · Gemini · mock)
   stages/{ingest,research,recon,audit,sca,second_opinion,validate,corroborate,deep_verify,asan_poc,runtime,live,report}.py
   research.py·fixes.py·verify.py·benchmark.py·chat.py·costs.py·archetype.py
   prompts/             # the assets, version-controlled in git
@@ -204,14 +204,15 @@ argo pipeline --repo ./my-code                                 # 🔐 local/pers
 
 **Auditing your own / private local code?** Omit `--brief` and point `--repo` at a **local folder**
 (it does not need to be a git repo, and is **never pushed anywhere**). Argo synthesizes a minimal
-**source-only** scope from the folder and audits it. A **cloud backend** (Claude / Codex) sends the
-source to that provider's API to analyze it — only a **local / OSS model** (`--codex-oss`) keeps
-everything **fully on-device**.
+**source-only** scope from the folder and audits it. A **cloud backend** (Claude / Codex / Gemini)
+sends the source to that provider's API to analyze it — only a **local / OSS model** (`--codex-oss`)
+keeps everything **fully on-device**.
 
 Pick a backend (default `headless` = Claude Code):
 ```
 argo pipeline ... --runner codex                                  # Codex CLI / OpenAI
 argo pipeline ... --runner codex --codex-oss --codex-local-provider ollama --codex-model qwen2.5-coder:32b
+argo pipeline ... --runner gemini                                 # Gemini CLI / Google
 ```
 
 Low-cost modes:
@@ -264,7 +265,8 @@ Each stage reads the previous one's output and writes its own — full detail, d
 
 Same pipeline, swappable engine — pick what you have: `--runner headless` (Claude Code) ·
 `--runner codex` (Codex CLI → OpenAI, or `--codex-oss --codex-local-provider ollama|lmstudio` for
-**local open-source models** like Qwen/DeepSeek, fully free and on-device) · `--runner mock` (free
+**local open-source models** like Qwen/DeepSeek, fully free and on-device) · `--runner gemini`
+(Gemini CLI → Google, tiered pro/flash/flash-lite per stage like Claude) · `--runner mock` (free
 fixtures). Backends and accounts chain transparently on a rate limit or transient failure, so a long
 run self-heals instead of stalling. Full model-per-stage defaults, the resilience/fallback design,
 and the cross-model study: **[docs/backends.md](docs/backends.md)**.
@@ -299,7 +301,7 @@ This README is the conceptual overview. Deeper, implementation-level docs live i
 | [docs/cli-reference.md](docs/cli-reference.md) | Every command and flag, with examples (`--smoke`, `--budget`, caps, `--calibration`, …) |
 | [docs/guardrails.md](docs/guardrails.md) | The non-negotiable guardrails and **exactly where each is enforced in code** |
 | [docs/design-decisions.md](docs/design-decisions.md) | **Why** Argo is LLM-direct with **no CPG/AST engine**, what it uses instead, when we'd revisit, and threats to validity (paper-facing) |
-| [docs/backends.md](docs/backends.md) | **Multi-backend**: run on Claude Code, the Codex CLI (OpenAI), or local/open-source models — the abstraction, per-backend guardrail mapping, cost, cross-model study |
+| [docs/backends.md](docs/backends.md) | **Multi-backend**: run on Claude Code, the Codex CLI (OpenAI), the Gemini CLI (Google), or local/open-source models — the abstraction, per-backend guardrail mapping, cost, cross-model study |
 | [docs/headless-runner.md](docs/headless-runner.md) | Real Claude Code integration: flags used, the JSON envelope, caps, error handling, partial recovery, the `--smoke` run |
 | [docs/api.md](docs/api.md) | The HTTP API (`server/`) — backend for the web UI: endpoints, run lifecycle, live status/SSE, artifact whitelist |
 | [docs/ui.md](docs/ui.md) | The web UI (`webapp/`) — `python -m argo.cli serve`, the no-build stack, the views |

--- a/argo/cli.py
+++ b/argo/cli.py
@@ -54,6 +54,9 @@ def _build_config(
     fallback: Optional[str] = None,
     claude_accounts: Optional[str] = None,
     codex_accounts: Optional[str] = None,
+    gemini_model: Optional[str] = None,
+    gemini_api_key: Optional[str] = None,
+    gemini_accounts: Optional[str] = None,
 ) -> PipelineConfig:
     cfg = PipelineConfig(
         runner=runner,
@@ -66,11 +69,20 @@ def _build_config(
         codex_model=codex_model,
         codex_oss=codex_oss,
         codex_local_provider=codex_local_provider,
+        gemini_api_key=gemini_api_key,
     )
+    if gemini_model:
+        # Flat override across every stage (mirrors --codex-model's convenience) -- fans out into
+        # the per-stage dict at config-build time rather than adding a redundant flat config field.
+        # Applied BEFORE calibration/--audit-model below, so those can still override individual
+        # stages (e.g. --gemini-model + --calibration => every stage flattened, THEN audit bumped
+        # to Pro) rather than being silently clobbered by a flat override applied after them.
+        cfg = cfg.with_overrides(
+            gemini_stage_models={k: gemini_model for k in cfg.gemini_stage_models})
     if timeout is not None:
         cfg = cfg.with_overrides(session_timeout_s=timeout)
     if calibration:
-        cfg = cfg.calibrated()            # audit -> Opus
+        cfg = cfg.calibrated()            # audit -> Opus (or Gemini Pro, if runner == "gemini")
     if audit_model:
         cfg = cfg.with_stage_model("audit", audit_model)
     if fallback:
@@ -82,17 +94,36 @@ def _build_config(
     if codex_accounts:
         dirs = [d.strip() for d in codex_accounts.split(",") if d.strip()]
         cfg = cfg.with_overrides(codex_accounts=dirs)
+    if gemini_accounts:
+        keys = [k.strip() for k in gemini_accounts.split(",") if k.strip()]
+        cfg = cfg.with_overrides(gemini_accounts=keys)
     return cfg
 
 
 RunnerOpt = typer.Option("headless", "--runner",
-                         help="headless (Claude Code CLI) · codex (Codex CLI / OpenAI / OSS) · mock")
+                         help="headless (Claude Code CLI) · codex (Codex CLI / OpenAI / OSS) · "
+                              "gemini (Gemini CLI) · mock")
 CodexModelOpt = typer.Option(None, "--codex-model",
                              help="(runner=codex) model id, e.g. gpt-5-codex; omit to use the "
                                   "Codex CLI's own default")
 CodexOssOpt = typer.Option(False, "--codex-oss", help="(runner=codex) use the open-source provider (--oss)")
 CodexProviderOpt = typer.Option(None, "--codex-local-provider",
                                 help="(runner=codex --codex-oss) ollama | lmstudio")
+GeminiModelOpt = typer.Option(
+    None, "--gemini-model",
+    help="(runner=gemini) flat override across every stage, e.g. gemini-3.1-pro; applied before "
+         "--calibration/--audit-model so those can still bump individual stages on top. Omit to "
+         "use the built-in per-stage tiering (DEFAULT_GEMINI_STAGE_MODELS).")
+GeminiApiKeyOpt = typer.Option(
+    None, "--gemini-api-key",
+    help="(runner=gemini) GEMINI_API_KEY value for this run; omit to use the ambient env var / "
+         "existing gemini CLI login. A real secret -- redacted in runs/<id>/config.json, so "
+         "`argo resume` on a Gemini run needs it re-supplied.")
+GeminiAccountsOpt = typer.Option(
+    None, "--gemini-accounts",
+    help="comma-separated GEMINI_API_KEY VALUES to chain across (multi-account; limits are "
+         "per-key). Unlike --claude-accounts/--codex-accounts these are raw secret values, not "
+         "directory paths -- e.g. --gemini-accounts key-a,key-b")
 AuditModelOpt = typer.Option(None, "--audit-model", help="override the Stage-3 audit model")
 CalibrationOpt = typer.Option(False, "--calibration", help="run audit on Opus (all-Opus)")
 BudgetOpt = typer.Option(None, "--budget", help="HARD per-run USD ceiling; aborts further sessions")
@@ -645,13 +676,17 @@ def estimate(
     codex_local_provider: Optional[str] = CodexProviderOpt, fallback: Optional[str] = FallbackOpt,
     claude_accounts: Optional[str] = ClaudeAccountsOpt,
     codex_accounts: Optional[str] = CodexAccountsOpt,
+    gemini_model: Optional[str] = GeminiModelOpt, gemini_api_key: Optional[str] = GeminiApiKeyOpt,
+    gemini_accounts: Optional[str] = GeminiAccountsOpt,
 ):
     """Run ingest+recon only, classify the target, and print a pre-audit cost estimate."""
     cfg = _build_config(runner, audit_model, calibration, budget, parallel, runs_dir, scenario,
                         timeout=timeout, max_turns=max_turns, session_budget=session_budget,
                         codex_model=codex_model, codex_oss=codex_oss,
                         codex_local_provider=codex_local_provider, fallback=fallback,
-                        claude_accounts=claude_accounts, codex_accounts=codex_accounts)
+                        claude_accounts=claude_accounts, codex_accounts=codex_accounts,
+                        gemini_model=gemini_model, gemini_api_key=gemini_api_key,
+                        gemini_accounts=gemini_accounts)
     cfg = cfg.with_overrides(sca_enabled=sca, research_enabled=research, runtime_enabled=runtime,
                              runtime_image=runtime_image, runtime_run_cmd=runtime_run_cmd,
                              corroborate_enabled=corroborate, doc_links=list(docs_url or []),
@@ -778,6 +813,8 @@ def pipeline(
     codex_local_provider: Optional[str] = CodexProviderOpt, fallback: Optional[str] = FallbackOpt,
     claude_accounts: Optional[str] = ClaudeAccountsOpt,
     codex_accounts: Optional[str] = CodexAccountsOpt,
+    gemini_model: Optional[str] = GeminiModelOpt, gemini_api_key: Optional[str] = GeminiApiKeyOpt,
+    gemini_accounts: Optional[str] = GeminiAccountsOpt,
     attribution: bool = AttributionOpt,
 ):
     """Run stages 1-5 and STOP at human-review drafts. Never submits."""
@@ -785,7 +822,9 @@ def pipeline(
                         timeout=timeout, max_turns=max_turns, session_budget=session_budget,
                         codex_model=codex_model, codex_oss=codex_oss,
                         codex_local_provider=codex_local_provider, fallback=fallback,
-                        claude_accounts=claude_accounts, codex_accounts=codex_accounts)
+                        claude_accounts=claude_accounts, codex_accounts=codex_accounts,
+                        gemini_model=gemini_model, gemini_api_key=gemini_api_key,
+                        gemini_accounts=gemini_accounts)
     cfg = cfg.with_overrides(sca_enabled=sca, research_enabled=research, runtime_enabled=runtime,
                              runtime_image=runtime_image, runtime_run_cmd=runtime_run_cmd,
                              corroborate_enabled=corroborate, doc_links=list(docs_url or []),
@@ -801,9 +840,10 @@ def pipeline(
         cfg = cfg.with_overrides(audit_critic_passes=critic_passes)
     if smoke:
         cfg = cfg.for_smoke()                              # cheapest model, 1 focus, low caps
-        # for_smoke() defaults to the Claude backend; honor an explicit --runner (e.g. codex).
+        # for_smoke() defaults to the Claude backend; honor an explicit --runner (e.g. codex, gemini).
         cfg = cfg.with_overrides(runner=runner, codex_model=codex_model, codex_oss=codex_oss,
-                                 codex_local_provider=codex_local_provider)
+                                 codex_local_provider=codex_local_provider,
+                                 gemini_api_key=gemini_api_key)
         research = False                                   # a cheap smoke stays fully offline
         cfg = cfg.with_overrides(research_enabled=False,
                                  corroborate_enabled=False)  # ...and skips the networked cross-check

--- a/argo/config.py
+++ b/argo/config.py
@@ -18,6 +18,16 @@ OPUS = "claude-opus-5"
 SONNET = "claude-sonnet-5"
 HAIKU = "claude-haiku-4-5-20251001"  # cheapest; used for the headless smoke run
 
+# --- Model IDs (Gemini CLI backend). Pinned concrete ids, never the auto-resolving
+# "pro"/"flash" aliases: an alias breaks MODEL_PRICING's substring match, run-to-run
+# reproducibility, and (confirmed empirically against gemini-cli v0.49.0) can trigger an
+# extra internal "which model should handle this" routing call that a pinned id skips
+# entirely. Re-confirm these strings periodically -- preview ids churn; there is no
+# `--list-models` flag, these were read directly off real `stats.models` keys.
+GEMINI_PRO = "gemini-3.1-pro"
+GEMINI_FLASH = "gemini-3.5-flash"
+GEMINI_FLASH_LITE = "gemini-3.1-flash-lite"  # cheapest; used for the Gemini smoke run
+
 #: Default per-stage model assignment.
 #:  * ingest   -> Sonnet (never Haiku: misreading scope/RoE has outsized consequences).
 #:  * recon    -> Opus   (judgment-heavy synthesis, low volume).
@@ -42,6 +52,26 @@ DEFAULT_STAGE_MODELS: dict[str, str] = {
     "asan_poc": OPUS,   # single-shot, precision-critical harness authoring (opt-in, C/C++ only)
 }
 
+#: Default per-stage model assignment for the Gemini backend. Same placement rationale as
+#: DEFAULT_STAGE_MODELS above (Pro for judgment-heavy/low-volume stages, Flash for high-volume
+#: fan-out) -- Gemini's pro/flash tier genuinely maps onto that split, unlike Codex's flat model.
+DEFAULT_GEMINI_STAGE_MODELS: dict[str, str] = {
+    "ingest": GEMINI_FLASH,
+    "recon": GEMINI_PRO,
+    "audit": GEMINI_FLASH,
+    "validate": GEMINI_PRO,
+    "report": GEMINI_FLASH,
+    "chat": GEMINI_FLASH,
+    "remediate": GEMINI_PRO,
+    "research": GEMINI_FLASH,
+    "sca": GEMINI_PRO,
+    "runtime": GEMINI_FLASH,
+    "live": GEMINI_FLASH,
+    "corroborate": GEMINI_FLASH,
+    "verify": GEMINI_PRO,
+    "asan_poc": GEMINI_PRO,
+}
+
 #: Default per-stage wall-clock overrides (seconds). Recon now does deep ground-truth extraction
 #: (enumerating variant families, baseline-correct refs, invariants across the whole tree) and the
 #: audit walks every family member — both want more headroom than the 1800s global default. The
@@ -55,12 +85,17 @@ DEFAULT_STAGE_TIMEOUTS: dict[str, int] = {
 
 # --- Cost estimation for backends that report tokens but not USD ---------------------
 # Claude Code returns an authoritative ``total_cost_usd`` per call. The Codex CLI (OpenAI / OSS)
-# reports tokens, not dollars, so for it we ESTIMATE: tokens x this rough price table. Figures are
-# USD per 1M tokens (input, output); used only for the budget guard + cost analytics, never billed.
-# Unknown models (incl. ``--oss`` / local) estimate to $0 — tokens are still logged.
+# and the Gemini CLI report tokens, not dollars, so for both we ESTIMATE: tokens x this rough price
+# table. Figures are USD per 1M tokens (input, output); used only for the budget guard + cost
+# analytics, never billed. Unknown models (incl. ``--oss`` / local) estimate to $0 — tokens are
+# still logged. Gemini figures confirmed 2026-08-17 from ai.google.dev/gemini-api/docs/pricing
+# (standard tier, <=200k-token prompts; Pro steps up to $4/$18 above 200k -- not modeled here,
+# estimate_cost_usd doesn't take a prompt-size argument, so very large Pro-tier prompts undercount
+# slightly rather than justify a tiered lookup for a rare case).
 MODEL_PRICING: dict[str, tuple[float, float]] = {
     "gpt-5.5": (1.25, 10.0), "gpt-5-codex": (1.25, 10.0), "gpt-5": (1.25, 10.0),
     "gpt-4o": (2.5, 10.0), "gpt-4.1": (2.0, 8.0), "o4-mini": (1.1, 4.4), "o3": (2.0, 8.0),
+    GEMINI_PRO: (2.00, 12.00), GEMINI_FLASH: (1.50, 9.00), GEMINI_FLASH_LITE: (0.25, 1.50),
 }
 
 
@@ -122,9 +157,12 @@ class PipelineConfig:
 
     # Model assignment per stage.
     stage_models: dict[str, str] = field(default_factory=lambda: dict(DEFAULT_STAGE_MODELS))
+    # Gemini backend's own per-stage assignment (Gemini is tiered like Claude, not flat like Codex —
+    # see DEFAULT_GEMINI_STAGE_MODELS). Only consulted when runner == "gemini".
+    gemini_stage_models: dict[str, str] = field(default_factory=lambda: dict(DEFAULT_GEMINI_STAGE_MODELS))
 
     # Execution.
-    runner: str = "headless"            # "headless" (Claude Code) | "codex" (Codex CLI) | "mock"
+    runner: str = "headless"            # "headless" (Claude Code) | "codex" (Codex CLI) | "gemini" (Gemini CLI) | "mock"
     # Resilience: ordered fallback backends. When the primary runner hits a retryable limit
     # (session-limit / rate-limit / 429), the same call is transparently retried on the next backend
     # (e.g. ["codex"] => Claude -> Codex). A walled backend is skipped for the rest of the run.
@@ -140,6 +178,13 @@ class PipelineConfig:
     # ordered list of CODEX_HOME dirs -> the codex backend becomes an account-fallback chain.
     codex_home: str | None = None
     codex_accounts: list[str] = field(default_factory=list)
+    # Multi-account Gemini: unlike Claude/Codex's directory-based accounts, Gemini's practical
+    # automation-auth lever is the GEMINI_API_KEY env var, so ``gemini_accounts`` holds ordered KEY
+    # VALUES (not directory paths) -- a deliberate deviation from the Claude/Codex pattern, not an
+    # inconsistency. These are real secrets (the credential lives IN the value, not on disk outside
+    # Argo's state) -- see _SECRET_FIELDS below, which redacts both from runs/<id>/config.json.
+    gemini_api_key: str | None = None
+    gemini_accounts: list[str] = field(default_factory=list)
     max_parallel_audits: int = 3        # concurrency cap for Stage 3 / Stage 4 fan-out
     # Efficiency: validate/corroborate historically span ONE session per finding, which is ~90% of a
     # run's sessions and the main driver of rate-limit exhaustion. Batching groups N findings into a
@@ -332,6 +377,12 @@ class PipelineConfig:
         # real id via -m only when codex_model is set, else the Codex CLI's own default is used).
         if self.runner == "codex":
             return self.codex_model or _codex_default_model() or "codex-default"
+        # Gemini is tiered per stage like Claude, via its own dict (see DEFAULT_GEMINI_STAGE_MODELS).
+        if self.runner == "gemini":
+            try:
+                return self.gemini_stage_models[stage]
+            except KeyError:  # pragma: no cover - defensive
+                raise KeyError(f"No Gemini model configured for stage {stage!r}") from None
         try:
             return self.stage_models[stage]
         except KeyError:  # pragma: no cover - defensive
@@ -345,13 +396,20 @@ class PipelineConfig:
         return replace(self, **kwargs)
 
     def with_stage_model(self, stage: str, model: str) -> "PipelineConfig":
+        if self.runner == "gemini":
+            models = dict(self.gemini_stage_models)
+            models[stage] = model
+            return replace(self, gemini_stage_models=models)
         models = dict(self.stage_models)
         models[stage] = model
         return replace(self, stage_models=models)
 
     def calibrated(self) -> "PipelineConfig":
-        """Calibration default: run the audit stage on Opus (effectively all-Opus) so a
-        weak prompt is never confounded with a weak model when diagnosing missed bugs."""
+        """Calibration default: run the audit stage on the backend's top-tier model
+        (effectively all-Opus / all-Pro) so a weak prompt is never confounded with a
+        weak model when diagnosing missed bugs."""
+        if self.runner == "gemini":
+            return self.with_stage_model("audit", GEMINI_PRO)
         return self.with_stage_model("audit", OPUS)
 
     def for_smoke(self) -> "PipelineConfig":
@@ -361,13 +419,21 @@ class PipelineConfig:
 
         Recon uses Sonnet (not Haiku): the synthesis stage is guardrail-gated (each generated
         prompt must carry the RoE + prohibited techniques + 'Do NOT patch' verbatim), and Haiku
-        is too unreliable at reproducing the template. Every other stage stays on Haiku."""
+        is too unreliable at reproducing the template. Every other stage stays on Haiku.
+
+        Primes BOTH stage_models (Claude) and gemini_stage_models (Gemini) unconditionally, same
+        reasoning either way: the CLI's --smoke flow calls for_smoke() first, then re-applies the
+        actually-requested --runner afterward (see cli.py), so whichever backend ends up selected
+        must already have its cheap dict ready."""
         models = {k: HAIKU for k in self.stage_models}
         models["recon"] = SONNET
+        gemini_models = {k: GEMINI_FLASH_LITE for k in self.gemini_stage_models}
+        gemini_models["recon"] = GEMINI_FLASH
         return replace(
             self,
             runner="headless",
             stage_models=models,
+            gemini_stage_models=gemini_models,
             budget_usd=2.0,
             stage_timeouts={},            # smoke stays cheap: no deep recon/audit overrides
             session_timeout_s=600,        # sonnet recon explores the repo; give it headroom
@@ -381,6 +447,14 @@ class PipelineConfig:
 
 _PATH_FIELDS = {"runs_dir", "prompts_dir", "ledger_path", "fixtures_dir"}
 
+# Fields holding real secret material (as opposed to claude_config_dir/codex_home, which are just
+# directory paths -- the credential lives on disk outside Argo's state, not in the field value
+# itself). Gemini's practical auth lever is GEMINI_API_KEY, so these two DO carry raw key values.
+# Every PipelineConfig field is serialized verbatim into runs/<id>/config.json for `argo resume` /
+# `argo chat` to read back -- redact these two so a run directory never leaks a live API key.
+_SECRET_FIELDS = {"gemini_api_key", "gemini_accounts"}
+_REDACTED = "<redacted>"
+
 
 def _jsonable(value):
     if isinstance(value, Path):
@@ -393,8 +467,18 @@ def _jsonable(value):
 
 
 def pipeline_config_to_dict(config: PipelineConfig) -> dict:
-    """Return a JSON-safe representation of the effective PipelineConfig."""
-    return {f.name: _jsonable(getattr(config, f.name)) for f in fields(PipelineConfig)}
+    """Return a JSON-safe representation of the effective PipelineConfig. Secret-bearing fields
+    (see _SECRET_FIELDS) are redacted -- `argo resume` on a Gemini run needs the key re-supplied,
+    a narrow, deliberate deviation from resume's normal zero-flags-needed behavior."""
+    out = {}
+    for f in fields(PipelineConfig):
+        if f.name in _SECRET_FIELDS:
+            value = getattr(config, f.name)
+            out[f.name] = ([_REDACTED] * len(value)) if isinstance(value, list) else (
+                _REDACTED if value else value)
+        else:
+            out[f.name] = _jsonable(getattr(config, f.name))
+    return out
 
 
 def pipeline_config_from_dict(raw: dict) -> PipelineConfig:

--- a/argo/runner.py
+++ b/argo/runner.py
@@ -598,6 +598,217 @@ class CodexRunner(AgentRunner):
         )
 
 
+# ------------------------------------------------------------------------------- gemini
+#: Policy Engine TOML (see docs/backends.md "Gemini specifics"). A DENY-list, not an allow-list:
+#: enumerating every Gemini tool name Claude's ARTIFACT_TOOLS would map onto is unnecessary and
+#: fragile (some names, e.g. an Edit/MultiEdit equivalent, are unconfirmed) — a small, well-
+#: confirmed deny-list is simpler AND safer. run_shell_command is denied unconditionally (Argo never
+#: needs shell, mirrors Bash living in ALWAYS_DISALLOWED); everything else --approval-mode yolo
+#: auto-approves. Confirmed live 2026-08-17 (gemini-cli v0.49.0): a denied tool is removed from the
+#: model's declared tool set entirely (it reports having no such tool), not merely blocked post-call
+#: — clean, headless-safe, and unlike --sandbox has zero external (Docker/Podman) dependency.
+#:
+#: Repo-write safety does NOT depend on this policy: argo/stages/ingest.py:_make_readonly already
+#: os.chmod's the acquired repo copy read-only, backend-agnostically, before any runner touches it —
+#: a write_file call into repo_dir fails at the OS level regardless of what this policy allows.
+_GEMINI_POLICY_OFFLINE = """\
+[[rule]]
+toolName = "run_shell_command"
+decision = "deny"
+priority = 100
+
+[[rule]]
+toolName = ["google_web_search", "web_fetch"]
+decision = "deny"
+priority = 100
+"""
+
+#: Network carve-out for the research/corroborate stages ONLY — same two tools the OSINT_TOOLS
+#: exception permits on Claude, mirroring CodexRunner._build_codex_cmd's exact
+#: `if policy is not None and policy.network:` branch shape (an extra sandbox cfg flag there;
+#: here, simply omitting the two web-tool deny rules). Shell stays denied even here — no stage
+#: is ever permitted a shell tool, network or not.
+_GEMINI_POLICY_NETWORK = """\
+[[rule]]
+toolName = "run_shell_command"
+decision = "deny"
+priority = 100
+"""
+
+#: Gemini's soft safety refusals arrive as ordinary first-person declining prose inside a NORMAL,
+#: success-shaped envelope (confirmed live 2026-08-17 against gemini-cli v0.49.0 — no structured
+#: finishReason field is surfaced by the CLI's --output-format json output, unlike the raw Gemini
+#: API). Unlike Claude's/Codex's fixed classifier-boilerplate signatures, there is no stable marker
+#: string to match reliably on its own ("I cannot provide ..." also shows up in mundane, non-refusal
+#: replies) — so this requires a first-person refusal phrase to CO-OCCUR with a safety/
+#: authorization-flavored word. A conservative heuristic that trades recall for precision: a genuine
+#: refusal phrased unusually may be missed and surface as a downstream "no artifact produced"
+#: failure instead of a clean moderation_flagged one — a known, documented gap, not a silent one.
+_GEMINI_REFUSAL_PHRASES = ("i cannot provide", "i can't provide", "i cannot assist", "i can't assist",
+                          "i'm not able to provide", "i am not able to provide",
+                          "i cannot help with", "i can't help with")
+_GEMINI_REFUSAL_CONTEXT_WORDS = ("unauthorized", "malicious", "attack", "destroy", "exploit",
+                                 "illegal", "harmful", "victim")
+#: Argo-owned marker prepended to a detected soft refusal's text, so the SHARED, module-level
+#: _classify_failure_text (called from the base class's generic is_error path, which this backend
+#: cannot override in isolation) has something concrete to match — the same bridge mechanism
+#: Claude's/Codex's own fixed signatures use, just fed by a heuristic instead of a literal string.
+_GEMINI_MODERATION_MARKER = "argo-gemini-heuristic-refusal-detected"
+
+
+def _looks_like_gemini_refusal(text: str) -> bool:
+    s = (text or "").lower()
+    return (any(p in s for p in _GEMINI_REFUSAL_PHRASES)
+            and any(w in s for w in _GEMINI_REFUSAL_CONTEXT_WORDS))
+
+
+class GeminiRunner(AgentRunner):
+    """Runs the **Gemini CLI** (`gemini`) — Google's Gemini models, tiered per stage like Claude
+    (pro/flash/flash-lite; see DEFAULT_GEMINI_STAGE_MODELS), unlike Codex's flat single model.
+
+    Every design choice below reflects EMPIRICAL testing against a real `gemini` CLI (v0.49.0,
+    2026-08-17), not docs alone — see the Gemini backend plan's "Phase 0" for the full findings:
+
+      * The prompt is piped via **stdin only** (no `-p`) — confirmed to trigger the identical
+        non-interactive JSON path, and avoids `-p`'s documented stdin-APPENDS-not-replaces quirk.
+      * ``--skip-trust`` is REQUIRED on every call — a fresh, never-interactively-trusted scratch
+        dir otherwise makes the CLI exit 55 ("not running in a trusted directory").
+      * ``--include-directories <repo_dir>`` grants read access to the target repo (confirmed via
+        a real cross-directory read), which stays outside the scratch cwd, same layout as Codex.
+      * Guardrails map onto the **Policy Engine** (``--policy <toml>``), NOT ``--sandbox`` — see
+        `_GEMINI_POLICY_OFFLINE`'s docstring for why (a hard, unreliable Docker/Podman dependency
+        that failed outright in Phase 0 testing, confirmed live, vs. zero-dependency and confirmed
+        working). ``--approval-mode yolo`` auto-approves whatever the policy doesn't deny — every
+        Argo stage's session needs to Write its artifact, mirroring Claude's bypassPermissions /
+        Codex's non-interactive exec.
+      * Cost is **estimated** from token usage (like Codex — Gemini reports tokens, not USD), but
+        MUST be summed across every entry in ``stats.models``: omitting `-m` was found to trigger
+        an extra internal "utility_router" model call that also lands in that dict; Argo always
+        pins `-m`, so in practice there is usually exactly one entry, but the code must not assume
+        that.
+    """
+
+    def __init__(self, config: PipelineConfig, ledger: Ledger, gemini_bin: str = "gemini"):
+        super().__init__(config, ledger)
+        self.gemini_bin = gemini_bin
+        self._resolved_bin: str | None = None
+
+    def _bin(self) -> str:
+        if self._resolved_bin is None:
+            resolved = shutil.which(self.gemini_bin)
+            if not resolved:
+                raise RunnerError(
+                    f"gemini CLI not found on PATH (looked for {self.gemini_bin!r}); "
+                    "install the Gemini CLI or use --runner headless/codex/mock")
+            self._resolved_bin = resolved
+        return self._resolved_bin
+
+    def _build_gemini_cmd(self, *, model, repo_dir, policy_file: Path) -> list[str]:
+        cmd = [
+            self._bin(),
+            "--output-format", "json",
+            "--skip-trust",              # see class docstring — required for a fresh scratch dir
+            "--approval-mode", "yolo",   # non-interactive auto-approve for whatever isn't denied
+            "-m", model,
+            "--policy", str(policy_file),
+        ]
+        if repo_dir is not None:
+            cmd += ["--include-directories", str(Path(repo_dir).resolve())]
+        return cmd
+
+    def _invoke(self, *, prompt, work_dir, model, repo_dir, allowed, disallowed, policy=None,
+               stage, run_id, label, session_budget_usd=None, timeout_s=None) -> dict:
+        policy_toml = (_GEMINI_POLICY_NETWORK if (policy is not None and policy.network)
+                      else _GEMINI_POLICY_OFFLINE)
+        policy_file = Path(work_dir) / ".argo_gemini_policy.toml"
+        policy_file.write_text(policy_toml, encoding="utf-8")
+        cmd = self._build_gemini_cmd(model=model, repo_dir=repo_dir, policy_file=policy_file)
+        timeout = timeout_s or self.config.session_timeout_s
+        # Multi-account: point this invocation at a specific Gemini API key so an account-fallback
+        # can switch keys (limits are per-key/project). See build_runner / _expand_backend. Unlike
+        # Claude/Codex's directory-based env vars, this is a real secret value, not a path.
+        env = None
+        if self.config.gemini_api_key:
+            env = {**os.environ, "GEMINI_API_KEY": self.config.gemini_api_key}
+        try:
+            proc = self._exec(cmd, prompt=prompt, cwd=work_dir, timeout=timeout, env=env)
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - real-runner path
+            raise RunnerError(
+                f"gemini session timed out after {timeout}s "
+                f"(stage={stage}, run_id={run_id}, label={label})",
+                retryable=True, failure_kind="timeout") from exc
+
+        # Exit codes 42 (invalid input) and 53 (turn-limit) are a stable, documented part of the
+        # CLI's exit-code contract, independent of the JSON-envelope shape gap Phase 0 closed —
+        # handled directly here (not via parse_envelope's generic is_error path) because they need
+        # DIFFERENT retryability that the generic path has no way to express: 42 is structurally
+        # unfixable by retrying, 53 is retryable with its own new FailureKind.
+        if proc.returncode == 42:
+            raise RunnerError(
+                f"gemini rejected invalid input (stage={stage}, run_id={run_id}, label={label}, "
+                f"exit=42)\nstderr tail:\n{(proc.stderr or '')[-1500:]}",
+                retryable=False)
+        if proc.returncode == 53:
+            raise RunnerError(
+                f"gemini session hit its turn limit (stage={stage}, run_id={run_id}, "
+                f"label={label}, exit=53)\nstderr tail:\n{(proc.stderr or '')[-1500:]}",
+                retryable=True, failure_kind="turn_limit_exceeded")
+
+        # A result envelope may arrive WITH a non-zero exit (e.g. the quota-error shape confirmed
+        # live: exit 1, a clean {"error": {...}} envelope on stdout) — prefer parsing stdout, and
+        # only fall back to a hard error if there is no usable JSON at all (e.g. the FatalSandbox
+        # Error startup-crash shape confirmed live: nothing on stdout, everything on stderr).
+        out = (proc.stdout or "").strip()
+        if out:
+            try:
+                envelope = json.loads(out)
+            except json.JSONDecodeError:
+                envelope = None
+            if isinstance(envelope, dict):
+                envelope["_exit_code"] = proc.returncode
+                return envelope  # parse_envelope validates shape + classifies is_error
+
+        kind = _classify_failure_text(proc.stderr) or "unknown_retryable"
+        raise RunnerError(
+            f"gemini produced no parseable JSON envelope (stage={stage}, run_id={run_id}, "
+            f"label={label}, exit={proc.returncode}); likely auth/startup/sandbox failure.\n"
+            f"stderr tail:\n{(proc.stderr or '')[-1500:]}",
+            retryable=True, failure_kind=kind)
+
+    def parse_envelope(self, raw: dict, *, model: str, prompt_sha256: str,
+                       work_dir: Path) -> LLMResult:
+        error = raw.get("error")
+        is_error = error is not None
+        if is_error:
+            text = (error.get("message") if isinstance(error, dict) else str(error)) or ""
+        else:
+            text = raw.get("response") or ""
+            if _looks_like_gemini_refusal(text):
+                # Bridge: force is_error so the base class's generic error path (and run()'s
+                # neutral-register retry) treats this the same as Claude's/Codex's moderation
+                # flags, even though the CLI itself returned a nominally successful envelope.
+                is_error = True
+                text = f"{_GEMINI_MODERATION_MARKER}: {text}"
+
+        in_tok = out_tok = 0
+        for entry in ((raw.get("stats") or {}).get("models") or {}).values():
+            tok = (entry or {}).get("tokens") or {}
+            # "prompt" (total context, incl. cached) not "input" (cached-excluded) — a deliberate
+            # safe-direction overestimate when caching is active, matching the same rounding
+            # rationale already documented for MODEL_PRICING's >200k-token Pro tier gap.
+            in_tok += int(tok.get("prompt", tok.get("input", 0)) or 0)
+            out_tok += int(tok.get("candidates", 0) or 0)
+
+        return LLMResult(
+            text=text, model=model, prompt_sha256=prompt_sha256, work_dir=work_dir,
+            input_tokens=in_tok, output_tokens=out_tok,
+            cost_usd=estimate_cost_usd(model, in_tok, out_tok),   # estimated (token-based)
+            num_turns=0, session_id=raw.get("session_id"),
+            stop_reason=f"exit_{raw.get('_exit_code', 0)}",
+            is_error=is_error, api_error_status=None, raw=raw,
+        )
+
+
 # ------------------------------------------------------------------------------- mock
 class MockClaudeRunner(ClaudeRunner):
     """Deterministic, zero-token runner. Writes fixture files into the session scratch dir
@@ -973,8 +1184,12 @@ class MockClaudeRunner(ClaudeRunner):
 
 #: Error-message hints that mark a session failure as RETRYABLE on another backend (vs a real
 #: deterministic failure that should propagate). Matched case-insensitively against the RunnerError.
+#: "quota" already matches Gemini's real observed 429 wording ("you exceeded your current quota",
+#: confirmed live 2026-08-17); resource_exhausted/"resource has been exhausted" are documented
+#: alternate Gemini API phrasings that just didn't happen to be the one that specific call produced.
 _RETRYABLE_HINTS = ("session limit", "rate limit", "rate_limit", "api_error_status=429", " 429",
-                    "overloaded", "quota", "too many requests", "insufficient_quota")
+                    "overloaded", "quota", "too many requests", "insufficient_quota",
+                    "resource_exhausted", "resource has been exhausted")
 
 
 def _is_retryable(exc: Exception) -> bool:
@@ -1020,7 +1235,8 @@ def _classify_failure_text(text: str | None) -> FailureKind | None:
     default rather than this function silently picking one.
     """
     s = (text or "").lower()
-    if _MODERATION_FLAG_SIGNATURE in s or _CLAUDE_REFUSAL_SIGNATURE in s:
+    if (_MODERATION_FLAG_SIGNATURE in s or _CLAUDE_REFUSAL_SIGNATURE in s
+            or _GEMINI_MODERATION_MARKER in s):
         return "moderation_flagged"
     if _CREDITS_EXHAUSTED_SIGNATURE in s:
         return "credits_exhausted"
@@ -1239,18 +1455,24 @@ def _build_one(config: PipelineConfig, ledger: Ledger, name: str) -> AgentRunner
         return HeadlessClaudeRunner(cfg, ledger)
     if name == "codex":
         return CodexRunner(cfg, ledger)
-    raise ValueError(f"unknown runner {name!r} (expected 'headless', 'codex', or 'mock')")
+    if name == "gemini":
+        return GeminiRunner(cfg, ledger)
+    raise ValueError(f"unknown runner {name!r} (expected 'headless', 'codex', 'gemini', or 'mock')")
 
 
 def _expand_backend(config: PipelineConfig, ledger: Ledger, name: str) -> list[AgentRunner]:
     """One backend name -> one or more runners. Multi-account backends expand to one runner per
-    credential dir (limits are per-account): Claude via CLAUDE_CONFIG_DIR, Codex via CODEX_HOME."""
+    credential dir (limits are per-account): Claude via CLAUDE_CONFIG_DIR, Codex via CODEX_HOME,
+    Gemini via a GEMINI_API_KEY value (a real secret, not a directory path — see PipelineConfig)."""
     if name == "headless" and config.claude_accounts:
         return [HeadlessClaudeRunner(config.with_overrides(runner=name, claude_config_dir=d), ledger)
                 for d in config.claude_accounts]
     if name == "codex" and config.codex_accounts:
         return [CodexRunner(config.with_overrides(runner=name, codex_home=d), ledger)
                 for d in config.codex_accounts]
+    if name == "gemini" and config.gemini_accounts:
+        return [GeminiRunner(config.with_overrides(runner=name, gemini_api_key=k), ledger)
+                for k in config.gemini_accounts]
     return [_build_one(config, ledger, name)]
 
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,9 +1,10 @@
 # Backends (model providers)
 
 Argo runs the same multi-stage pipeline on a **swappable agent backend**, so a user can run it with
-whatever they already have — **Claude Code**, the **Codex CLI** (OpenAI), or a **local / open-source**
-model — without changing the audit logic. This also makes Argo a vehicle for **cross-model
-comparison** in the study: identical prompts and pipeline, different model, measured side by side.
+whatever they already have — **Claude Code**, the **Codex CLI** (OpenAI), the **Gemini CLI**
+(Google), or a **local / open-source** model — without changing the audit logic. This also makes
+Argo a vehicle for **cross-model comparison** in the study: identical prompts and pipeline,
+different model, measured side by side.
 
 ## The abstraction
 
@@ -18,10 +19,11 @@ then delegates two per-backend steps:
 AgentRunner (ABC)
 ├─ HeadlessClaudeRunner   # `claude -p` — Claude Code
 ├─ CodexRunner            # `codex exec` — OpenAI, or local/OSS via --oss
+├─ GeminiRunner           # `gemini` — Google, tiered per stage like Claude
 └─ MockClaudeRunner       # fixtures (zero tokens; the test suite)
 ```
 
-`build_runner(config)` dispatches on `config.runner ∈ {headless, codex, mock}`.
+`build_runner(config)` dispatches on `config.runner ∈ {headless, codex, gemini, mock}`.
 
 ## The guardrails are backend-neutral, enforced per backend
 
@@ -29,24 +31,36 @@ The invariants are one **`SessionPolicy`** (`guardrails.session_policy(stage)`) 
 the `research` stage; the repo is never writable"* — and each backend translates it into its own CLI
 dialect. This is the safety-critical part and is unit-tested for **both** backends.
 
-| Guarantee | Claude (`HeadlessClaudeRunner`) | Codex (`CodexRunner`) |
-|---|---|---|
-| Repo **read-only** | repo via `--add-dir`; ingest also chmods it read-only | repo lives **outside** the workspace + chmod read-only → readable, not writable (we deliberately do **not** `--add-dir` the repo, which would make it writable) |
-| Writes only the scratch dir | session cwd = scratch + `Write` tool | `-s workspace-write` with cwd = scratch |
-| **No network** (all stages but research) | network tools stripped from the allowlist | `-s workspace-write` (sandbox denies egress) |
-| **Network only for `research`** | OSINT tools kept for that one stage | `-c sandbox_workspace_write.network_access=true` for that one stage |
-| No interactive blocking | `--permission-mode bypassPermissions` | `codex exec` is non-interactive (no approval prompt) |
-| Never a sandbox escape | network/mutation tools always disallowed | never `danger-full-access` / `--dangerously-bypass-*` |
+| Guarantee | Claude (`HeadlessClaudeRunner`) | Codex (`CodexRunner`) | Gemini (`GeminiRunner`) |
+|---|---|---|---|
+| Repo **read-only** | repo via `--add-dir`; ingest also chmods it read-only | repo lives **outside** the workspace + chmod read-only → readable, not writable (we deliberately do **not** `--add-dir` the repo, which would make it writable) | repo via `--include-directories`; the SAME `ingest`-time chmod backs this, backend-agnostically — see the note below |
+| Writes only the scratch dir | session cwd = scratch + `Write` tool | `-s workspace-write` with cwd = scratch | session cwd = scratch (no additional path-scoping beyond the repo chmod — see the note below) |
+| **No network** (all stages but research) | network tools stripped from the allowlist | `-s workspace-write` (sandbox denies egress) | Policy Engine denies `google_web_search`/`web_fetch` (and `run_shell_command`, always) |
+| **Network only for `research`**/`corroborate` | OSINT tools kept for those two stages | `-c sandbox_workspace_write.network_access=true` for those two stages | the two web-tool `deny` rules are simply omitted from the policy for those two stages |
+| No interactive blocking | `--permission-mode bypassPermissions` | `codex exec` is non-interactive (no approval prompt) | `--approval-mode yolo` |
+| Never a sandbox escape | network/mutation tools always disallowed | never `danger-full-access` / `--dangerously-bypass-*` | `run_shell_command` always denied; no yolo-mode escape hatch used |
 
-Tests: `tests/test_guardrails.py` (the policy + Claude tool stripping) and `tests/test_codex.py`
+Tests: `tests/test_guardrails.py` (the policy + Claude tool stripping), `tests/test_codex.py`
 (`test_build_cmd_is_sandboxed_and_offline_for_audit`, `test_only_research_gets_network` — the
-equivalent re-validation for the Codex sandbox).
+equivalent re-validation for the Codex sandbox), and `tests/test_gemini.py`
+(`test_offline_stage_denies_shell_and_web_tools`, `test_only_research_and_corroborate_get_network`
+— the equivalent for the Gemini Policy Engine).
 
 > **Note on the network guarantee.** For Claude, "no network" is enforced by the tool denylist
 > (a named-capability allowlist). For Codex it relies on the **OS sandbox** contract of
-> `workspace-write` (writes confined to the workspace, egress denied). We assert our command never
-> enables network outside `research` and never uses an escape flag; the sandbox itself is Codex's
-> enforcement. A real network-blocked smoke is recommended before high-stakes Codex use.
+> `workspace-write` (writes confined to the workspace, egress denied). For Gemini it is the **Policy
+> Engine** tool denylist (same *dialect* as Claude's — see "Gemini specifics" below for why this
+> backend does NOT use `--sandbox`). We assert our command never enables network outside
+> `research`/`corroborate` and never uses an escape flag; for Codex the sandbox itself is the
+> enforcement, for Gemini the Policy Engine's tool removal is. A real network-blocked smoke is
+> recommended before high-stakes Codex/Gemini use.
+>
+> **Note on repo-write safety across ALL three backends.** The strongest guarantee — the audited
+> repo is never mutated — does not actually come from any backend-specific mechanism above. It comes
+> from `argo/stages/ingest.py:_make_readonly`, which `os.chmod`'s every file in the acquired repo
+> copy to strip write bits **before any runner touches it**, identically regardless of which backend
+> the run uses. A `Write`/`write_file` call targeting a path inside the repo fails at the OS level no
+> matter what a backend's own sandbox/policy would otherwise allow.
 
 ## Codex specifics (`runner = codex`)
 
@@ -89,6 +103,88 @@ consequence: with Codex the hard *mid-session* budget kill is unavailable; the p
 between stages still applies, on the estimated cost. This is a deliberate, documented degradation —
 see [design-decisions.md](design-decisions.md).
 
+## Gemini specifics (`runner = gemini`)
+
+`gemini --output-format json --skip-trust --approval-mode yolo -m <model> --policy <toml>
+--include-directories <repo_dir>`, prompt on **stdin only** — no `-p` (confirmed: `-p` APPENDS
+stdin rather than replacing it, and piping the prompt alone triggers the identical non-interactive
+JSON path, avoiding that quirk and any OS argv-length limit on Argo's large audit prompts).
+`--skip-trust` is **required**: a fresh, never-interactively-trusted scratch dir otherwise makes the
+CLI exit 55 ("not running in a trusted directory") — every headless automation hits this, not just
+Argo. Options:
+
+- `--gemini-model <id>` (e.g. `gemini-3.1-pro`) — flat override across **every** stage, applied
+  before `--calibration`/`--audit-model` so those can still bump individual stages on top. Omit to
+  use the built-in per-stage tiering (below).
+- `--gemini-api-key <key>` — sets `GEMINI_API_KEY` for this run; omit to use the ambient env var or
+  an existing `gemini` CLI login (OAuth). **This is a real secret** (unlike `--claude-accounts`/
+  `--codex-accounts`, which are directory paths) — it is redacted to `<redacted>` in
+  `runs/<id>/config.json`, so `argo resume` on a Gemini run needs the key re-supplied via
+  `--gemini-api-key` again. A narrow, deliberate deviation from `resume`'s normal zero-flags
+  behavior.
+- `--gemini-accounts key-a,key-b` — chain multiple `GEMINI_API_KEY` **values** (multi-account,
+  limits are per-key). Unlike Claude's `CLAUDE_CONFIG_DIR` dirs or Codex's `CODEX_HOME` dirs, Gemini's
+  practical automation-auth lever is the key value itself, so this list holds raw secrets, not paths
+  — same redaction as above applies.
+
+### Why the Policy Engine, not `--sandbox`
+
+Gemini CLI has its own OS-level sandbox (`--sandbox` / `-s`), and an early version of this backend's
+design planned to use it, mirroring Codex's `-s workspace-write`. Empirical testing (2026-08-17,
+`gemini-cli` v0.49.0) found two problems that changed that plan:
+
+1. **Hard external dependency.** `--sandbox` pulls a remote Docker/Podman image
+   (`.../gemini-cli/sandbox:<version>`) and fails outright (`FatalSandboxError`) if no
+   Docker/Podman daemon is reachable — confirmed live: it failed on a dev machine that had Docker
+   Desktop *installed* but not *running*. Claude and Codex have no such dependency; making Gemini
+   runs less reliable than the other two backends purely because a daemon wasn't up would be a real
+   regression, not a wash.
+2. **Not network/write-decoupled on the one dependency-free path anyway.** On Windows without
+   Docker targeted, the CLI's own docs describe write-only confinement via `icacls` with no network
+   control at all; the Docker/Podman engine (Linux, the most relevant path for CI/production) has no
+   documented flag to keep writes confined while independently toggling network, the way Codex's
+   `sandbox_workspace_write.network_access` does.
+
+Instead, `GeminiRunner` uses the **Policy Engine** (`--policy <file>.toml`, `[[rule]] toolName=...
+decision="allow"|"deny"|"ask_user"`) — confirmed live: a `deny` rule removes the tool from the
+model's declared tool set entirely (the model reports having no such tool, never attempts the call),
+clean and headless-safe, zero external dependencies. This is structurally the same *dialect* Claude
+already uses (a named-tool allowlist/denylist), not Codex's OS-sandbox dialect — see the guardrails
+table above. Repo-write safety does not depend on this policy at all; see the ingest-chmod note
+above.
+
+### Model tiering
+
+Gemini is tiered per stage like Claude (not flat like Codex) — `DEFAULT_GEMINI_STAGE_MODELS`
+(`argo/config.py`):
+
+| Tier | Model | Stages |
+|---|---|---|
+| Pro | `gemini-3.1-pro` | recon, validate, verify, sca, remediate, asan_poc |
+| Flash | `gemini-3.5-flash` | ingest, audit, report, chat, research, runtime, live, corroborate |
+
+`for_smoke()` uses Flash-Lite (`gemini-3.1-flash-lite`) everywhere except recon (Flash) — the same
+reasoning as Claude's Haiku/Sonnet smoke split. Pricing (`config.MODEL_PRICING`, confirmed
+2026-08-17 from `ai.google.dev/gemini-api/docs/pricing`, USD/1M tokens, ≤200k-token prompts): Pro
+$2.00 in / $12.00 out, Flash $1.50 / $9.00, Flash-Lite $0.25 / $1.50. As of 2026-04-01 Pro has **no
+free tier** — only Flash/Flash-Lite retain free-tier access, which is exactly why the smoke config
+avoids Pro entirely.
+
+**Cost is estimated, not authoritative** — same caveat as Codex above (Gemini reports tokens, not
+USD). One extra wrinkle found empirically: if `-m` is omitted, the CLI makes an internal
+"utility_router" model call to pick a model, which also shows up in the envelope's token stats —
+Argo always pins `-m`, and `estimate_cost_usd` sums tokens across every model that appears in a
+call's stats regardless, so this never silently undercounts even in the (avoided) unpinned case.
+
+**Moderation handling is heuristic, not a fixed signature — a known, documented gap.** Unlike
+Claude's/Codex's classifiers, Gemini CLI does not surface a structured refusal signal in its JSON
+output; a soft safety refusal comes back as an ordinary **success**-shaped response containing
+declining prose. `GeminiRunner.parse_envelope` detects this via a conservative heuristic
+(a first-person refusal phrase co-occurring with a safety/authorization-flavored word) and forces
+the same `moderation_flagged` handling Claude/Codex get. A refusal phrased unusually enough to dodge
+the heuristic will instead surface as a downstream "no artifact produced" failure — worth knowing if
+a Gemini run behaves oddly on a sensitive-sounding brief.
+
 ## Verify your backend
 
 ```bash
@@ -98,6 +194,8 @@ python -m argo.cli pipeline --smoke                          # the bundled ~$1 C
 python -m argo.cli pipeline --smoke --runner codex          # uses your Codex default model
 # Codex (local / open-source) — free, needs Ollama/LM Studio running
 python -m argo.cli pipeline --smoke --runner codex --codex-oss --codex-local-provider ollama
+# Gemini (Google)           — needs GEMINI_API_KEY or an existing `gemini` CLI login
+python -m argo.cli pipeline --smoke --runner gemini
 ```
 
 `--smoke` keeps it cheap (one focus, low caps, research off). The mock runner (`--runner mock`)
@@ -109,11 +207,27 @@ covers the whole pipeline for free regardless of backend.
 > adversarial validation ran — the prompts are portable and the sandbox held. (Cost showed `$0`
 > because the model logged as `codex-default`; tokens are recorded — see the cost note above.)
 
+> **Validated end-to-end on real Gemini (2026-08-17, gemini-cli v0.49.0), honestly reported.** A
+> `--smoke --runner gemini` run on the bundled fixtures produced a real, complete `REPORT.md` with a
+> genuine finding (a left-pad prototype-pollution dependency, correctly surfaced by SCA → validate →
+> report) and correctly DROPPED three audit-hallucinated findings whose citations didn't ground in
+> the actual repo — real proof the full command → JSON-parse → cost-estimate → ledger → validate →
+> report chain works for real. **Not a fully clean run, reported as such rather than rounded up**:
+> `ingest`/`audit`/`sca` came back `is_error: false` (3 real logged sessions, $0.0755 total); `recon`
+> hit a REAL free-tier daily quota exhaustion mid-session ("You have exhausted your daily quota on
+> this model") — an operational constraint of Phase 0's own earlier testing having already spent a
+> chunk of a very thin free-tier allowance (confirmed: the quota error itself reported a limit of
+> just 20 requests/day for `gemini-3.5-flash`), not a GeminiRunner defect. What that failure *did*
+> prove: it was correctly classified and surfaced as a `RunnerError`, and Argo's existing (Gemini-
+> agnostic) recon partial-artifact recovery handled it gracefully — the pipeline still completed
+> with real output, zero Gemini-specific recovery code needed. A fully clean run needs either a paid
+> `GEMINI_API_KEY` or the free tier's daily quota to reset.
+
 ## Why this matters for the paper
 
 Keeping the pipeline LLM-direct (no CPG/AST — see [design-decisions.md](design-decisions.md)) means
 the *only* thing that changes between backends is the **model**. That turns Argo into a clean
 instrument for a **cross-model study**: same corpus, same prompts, same guardrails, different model →
 the precision (registry accept rate) and recall (benchmark) numbers become directly comparable across
-Claude / OpenAI / open-source models. The contribution is the pipeline + methodology; the backend is
-a knob.
+Claude / OpenAI / Google / open-source models. The contribution is the pipeline + methodology; the
+backend is a knob.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -128,10 +128,12 @@ executes. The one hard boundary: a run that stopped **before ingest finished** (
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--runner {headless\|codex\|mock}` | `headless` | `headless` = Claude Code · `codex` = Codex CLI (OpenAI / OSS) · `mock` = zero-token fixtures. See [backends.md](backends.md). |
+| `--runner {headless\|codex\|gemini\|mock}` | `headless` | `headless` = Claude Code · `codex` = Codex CLI (OpenAI / OSS) · `gemini` = Gemini CLI (Google) · `mock` = zero-token fixtures. See [backends.md](backends.md). |
 | `--codex-model MODEL` | — | (runner=codex) model id (e.g. `gpt-5-codex`); **omit to use the Codex CLI default** (recommended) |
 | `--codex-oss` | off | (runner=codex) use the open-source provider (`--oss`) |
 | `--codex-local-provider {ollama\|lmstudio}` | — | (runner=codex --codex-oss) which local provider |
+| `--gemini-model MODEL` | — | (runner=gemini) flat model override across every stage (e.g. `gemini-3.1-pro`); applied before `--calibration`/`--audit-model`. Omit to use the built-in per-stage tiering. |
+| `--gemini-api-key KEY` | — | (runner=gemini) sets `GEMINI_API_KEY` for this run; omit to use the ambient env var / an existing `gemini` CLI login. A real secret — redacted in `runs/<id>/config.json`; `argo resume` needs it re-supplied. |
 | `--audit-model MODEL` | — | override only the Stage-3 audit model |
 | `--calibration` | off | run audit on Opus (effectively all-Opus) |
 | `--budget USD` | none | **HARD** per-run ceiling; aborts remaining sessions once hit |

--- a/server/app.py
+++ b/server/app.py
@@ -164,7 +164,8 @@ def create_app(base_config: PipelineConfig | None = None) -> FastAPI:
     def models():
         """Available backends, their selectable models, and the token-cost price table — so the UI
         can offer model pickers and show cost estimates instead of free-text guessing."""
-        from argo.config import (DEFAULT_STAGE_MODELS, HAIKU, MODEL_PRICING, OPUS, SONNET,
+        from argo.config import (DEFAULT_GEMINI_STAGE_MODELS, DEFAULT_STAGE_MODELS, GEMINI_FLASH,
+                                 GEMINI_FLASH_LITE, GEMINI_PRO, HAIKU, MODEL_PRICING, OPUS, SONNET,
                                  _codex_default_model)
         return {
             "backends": [
@@ -176,8 +177,13 @@ def create_app(base_config: PipelineConfig | None = None) -> FastAPI:
                  "cost": "estimated (token-based)", "default": _codex_default_model(),
                  "oss_providers": ["ollama", "lmstudio"],
                  "models": [{"id": "gpt-5.5"}, {"id": "gpt-5-codex"}, {"id": "o4-mini"}, {"id": "o3"}]},
+                {"id": "gemini", "label": "Gemini CLI", "cost": "estimated (token-based)",
+                 "models": [{"id": GEMINI_PRO, "label": "Gemini 3.1 Pro"},
+                            {"id": GEMINI_FLASH, "label": "Gemini 3.5 Flash"},
+                            {"id": GEMINI_FLASH_LITE, "label": "Gemini 3.1 Flash-Lite"}]},
             ],
             "default_stage_models": DEFAULT_STAGE_MODELS,
+            "default_gemini_stage_models": DEFAULT_GEMINI_STAGE_MODELS,
             "pricing": [{"model": k, "input_per_mtok": v[0], "output_per_mtok": v[1]}
                         for k, v in sorted(MODEL_PRICING.items())],
         }

--- a/server/jobs.py
+++ b/server/jobs.py
@@ -32,7 +32,13 @@ class JobManager:
             codex_model=req.config.codex_model,
             codex_oss=req.config.codex_oss,
             codex_local_provider=req.config.codex_local_provider,
+            gemini_api_key=req.config.gemini_api_key,
         )
+        if req.config.gemini_model:
+            # Flat override across every stage, applied BEFORE calibration/audit_model below so
+            # those can still bump individual stages on top -- mirrors the CLI's _build_config.
+            cfg = cfg.with_overrides(
+                gemini_stage_models={k: req.config.gemini_model for k in cfg.gemini_stage_models})
         if req.config.calibration:
             cfg = cfg.calibrated()
         if req.config.audit_model:

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -11,7 +11,7 @@ class RunConfig(BaseModel):
     """The subset of PipelineConfig a client may set per run. Defaults are deliberately safe:
     ``runner="mock"`` means a request spends **zero tokens** unless the client opts into
     ``headless``."""
-    runner: str = Field("mock", description='"mock" (free) · "headless" (Claude Code) · "codex" (Codex CLI / OpenAI / OSS)')
+    runner: str = Field("mock", description='"mock" (free) · "headless" (Claude Code) · "codex" (Codex CLI / OpenAI / OSS) · "gemini" (Gemini CLI)')
     budget_usd: Optional[float] = Field(None, description="hard per-run USD ceiling")
     audit_model: Optional[str] = Field(None, description="override the Stage-3 audit model")
     calibration: bool = Field(False, description="run audit on Opus (all-Opus)")
@@ -21,6 +21,13 @@ class RunConfig(BaseModel):
     codex_model: Optional[str] = Field(None, description="(runner=codex) model id; omit for the Codex CLI default")
     codex_oss: bool = Field(False, description="(runner=codex) use the open-source provider")
     codex_local_provider: Optional[str] = Field(None, description="(runner=codex+oss) ollama | lmstudio")
+    gemini_model: Optional[str] = Field(
+        None, description="(runner=gemini) flat model override across every stage, e.g. "
+                          "gemini-3.1-pro; omit to use the built-in per-stage tiering")
+    gemini_api_key: Optional[str] = Field(
+        None, description="(runner=gemini) GEMINI_API_KEY for this run; omit to use the ambient "
+                          "env var / existing gemini CLI login. Never echoed back or persisted in "
+                          "the clear (see PipelineConfig._SECRET_FIELDS redaction).")
 
 
 class Settings(BaseModel):

--- a/tests/fixtures/real_gemini_envelope.json
+++ b/tests/fixtures/real_gemini_envelope.json
@@ -1,0 +1,89 @@
+{
+  "session_id": "30fae387-c78c-4f36-8976-48caced18ed5",
+  "response": "OK",
+  "stats": {
+    "models": {
+      "gemini-3.1-flash-lite": {
+        "api": {
+          "totalRequests": 1,
+          "totalErrors": 0,
+          "totalLatencyMs": 9199
+        },
+        "tokens": {
+          "input": 2929,
+          "prompt": 2929,
+          "candidates": 38,
+          "total": 3412,
+          "cached": 0,
+          "thoughts": 445,
+          "tool": 0
+        },
+        "roles": {
+          "utility_router": {
+            "totalRequests": 1,
+            "totalErrors": 0,
+            "totalLatencyMs": 9199,
+            "tokens": {
+              "input": 2929,
+              "prompt": 2929,
+              "candidates": 38,
+              "total": 3412,
+              "cached": 0,
+              "thoughts": 445,
+              "tool": 0
+            }
+          }
+        }
+      },
+      "gemini-3.5-flash": {
+        "api": {
+          "totalRequests": 1,
+          "totalErrors": 0,
+          "totalLatencyMs": 2005
+        },
+        "tokens": {
+          "input": 9373,
+          "prompt": 9373,
+          "candidates": 1,
+          "total": 9610,
+          "cached": 0,
+          "thoughts": 236,
+          "tool": 0
+        },
+        "roles": {
+          "main": {
+            "totalRequests": 1,
+            "totalErrors": 0,
+            "totalLatencyMs": 2005,
+            "tokens": {
+              "input": 9373,
+              "prompt": 9373,
+              "candidates": 1,
+              "total": 9610,
+              "cached": 0,
+              "thoughts": 236,
+              "tool": 0
+            }
+          }
+        }
+      }
+    },
+    "tools": {
+      "totalCalls": 0,
+      "totalSuccess": 0,
+      "totalFail": 0,
+      "totalDurationMs": 0,
+      "totalDecisions": {
+        "accept": 0,
+        "reject": 0,
+        "modify": 0,
+        "auto_accept": 0
+      },
+      "byName": {}
+    },
+    "files": {
+      "totalLinesAdded": 0,
+      "totalLinesRemoved": 0
+    }
+  }
+}

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -387,3 +387,39 @@ def test_build_runner_mixed_claude_and_codex_accounts(tmp_path):
             ["HeadlessClaudeRunner", "HeadlessClaudeRunner", "CodexRunner", "CodexRunner"]
     finally:
         ledger.close()
+
+
+def test_build_runner_multi_account_gemini_chain(tmp_path):
+    """Unlike Claude/Codex's directory-based accounts, gemini_accounts holds raw GEMINI_API_KEY
+    VALUES (a deliberate deviation -- see PipelineConfig's docstring) -- assert the chain expands
+    one GeminiRunner per key, each with that key installed on its own config."""
+    from argo.ledger import Ledger
+    from argo.runner import GeminiRunner
+    ledger = Ledger(tmp_path / "l.sqlite")
+    try:
+        cfg = PipelineConfig(runner="gemini", gemini_accounts=["key-a", "key-b"])
+        r = build_runner(cfg, ledger)
+        assert isinstance(r, FallbackRunner) and len(r._runners) == 2
+        assert all(isinstance(x, GeminiRunner) for x in r._runners)
+        assert [x.config.gemini_api_key for x in r._runners] == ["key-a", "key-b"]
+    finally:
+        ledger.close()
+
+
+def test_pipeline_config_to_dict_redacts_gemini_secrets():
+    """gemini_api_key/gemini_accounts carry REAL secret material (the credential lives in the
+    field value itself, unlike claude_config_dir/codex_home which are just directory paths) --
+    every PipelineConfig field is serialized verbatim into runs/<id>/config.json, so a live key
+    must never round-trip into that file in the clear."""
+    from argo.config import pipeline_config_to_dict
+    cfg = PipelineConfig(runner="gemini", gemini_api_key="sk-live-secret-value",
+                         gemini_accounts=["sk-a", "sk-b"])
+    d = pipeline_config_to_dict(cfg)
+    blob = str(d)
+    assert "sk-live-secret-value" not in blob
+    assert "sk-a" not in blob and "sk-b" not in blob
+    assert d["gemini_api_key"] == "<redacted>"
+    assert d["gemini_accounts"] == ["<redacted>", "<redacted>"]
+    # a config with no key set stays falsy, not spuriously "<redacted>"
+    empty = pipeline_config_to_dict(PipelineConfig(runner="gemini"))
+    assert empty["gemini_api_key"] is None and empty["gemini_accounts"] == []

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -1,0 +1,275 @@
+"""Gemini backend: command-construction guardrails (Policy Engine, not --sandbox — see
+argo/runner.py's module comments for why), envelope parsing over a REAL captured call, and the
+heuristic soft-refusal -> moderation_flagged bridge.
+
+Every design choice under test was verified against a real `gemini` CLI (v0.49.0, 2026-08-17)
+before being written, per the Gemini backend plan's Phase 0 — this file's docstrings cite what was
+actually observed, not assumed.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from argo.config import GEMINI_FLASH, GEMINI_FLASH_LITE, GEMINI_PRO, PipelineConfig, estimate_cost_usd
+from argo.guardrails import session_policy
+from argo.ledger import Ledger
+from argo.runner import (GeminiRunner, RunnerError, _GEMINI_MODERATION_MARKER,
+                         _GEMINI_POLICY_NETWORK, _GEMINI_POLICY_OFFLINE, _classify_failure_text,
+                         _looks_like_gemini_refusal, build_runner)
+
+from conftest import FIXTURES
+
+REAL = json.loads((FIXTURES / "real_gemini_envelope.json").read_text(encoding="utf-8"))
+
+
+def _runner(tmp_path, **cfg):
+    r = GeminiRunner(PipelineConfig(runner="gemini", **cfg), Ledger(tmp_path / "l.sqlite"))
+    r._resolved_bin = "gemini"   # avoid a PATH dependency in CI
+    return r
+
+
+# --------------------------------------------------------------- command construction
+def test_build_cmd_is_headless_safe_and_stdin_only(tmp_path):
+    r = _runner(tmp_path)
+    cmd = r._build_gemini_cmd(model="m", repo_dir=None, policy_file=tmp_path / "p.toml")
+    # stdin-only: no -p anywhere (confirmed live -- stdin alone triggers the same JSON path)
+    assert "-p" not in cmd
+    # trusted-folder + non-interactive auto-approve (confirmed live: --skip-trust is REQUIRED or
+    # the CLI exits 55 in a fresh, never-interactively-trusted scratch dir)
+    assert "--skip-trust" in cmd
+    assert cmd[cmd.index("--approval-mode") + 1] == "yolo"
+    assert cmd[cmd.index("-m") + 1] == "m"
+    assert cmd[cmd.index("--output-format") + 1] == "json"
+    # NEVER a sandbox dependency (confirmed live: --sandbox failed outright, hard Docker/Podman
+    # dependency, replaced by the Policy Engine -- see _GEMINI_POLICY_OFFLINE's docstring)
+    assert "--sandbox" not in cmd
+    r.ledger.close()
+
+
+def test_build_cmd_includes_repo_dir_for_read_access(tmp_path):
+    r = _runner(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cmd = r._build_gemini_cmd(model="m", repo_dir=repo, policy_file=tmp_path / "p.toml")
+    assert cmd[cmd.index("--include-directories") + 1] == str(repo.resolve())
+    without = r._build_gemini_cmd(model="m", repo_dir=None, policy_file=tmp_path / "p.toml")
+    assert "--include-directories" not in without
+    r.ledger.close()
+
+
+# --------------------------------------------------------------- Policy Engine guardrails (_invoke)
+class _FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout, self.stderr, self.returncode = stdout, stderr, returncode
+
+
+def _invoke(r, tmp_path, **overrides):
+    kw = dict(prompt="p", work_dir=tmp_path, model="m", repo_dir=None,
+              allowed=["Read"], disallowed=[], policy=session_policy("audit"), stage="audit",
+              run_id="R", label="x", timeout_s=5)
+    kw.update(overrides)
+    return r._invoke(**kw)
+
+
+def _success_envelope(text="ok", session_id="s1"):
+    return json.dumps({"session_id": session_id, "response": text, "stats": {"models": {}}})
+
+
+def test_offline_stage_denies_shell_and_web_tools(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    monkeypatch.setattr(r, "_exec", lambda *a, **k: _FakeProc(_success_envelope(), "", 0))
+    _invoke(r, tmp_path, policy=session_policy("audit"))
+    written = (tmp_path / ".argo_gemini_policy.toml").read_text(encoding="utf-8")
+    assert written == _GEMINI_POLICY_OFFLINE
+    assert "run_shell_command" in written and "google_web_search" in written and "web_fetch" in written
+    r.ledger.close()
+
+
+def test_only_research_and_corroborate_get_network(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    monkeypatch.setattr(r, "_exec", lambda *a, **k: _FakeProc(_success_envelope(), "", 0))
+    for stage in ("research", "corroborate"):
+        _invoke(r, tmp_path, policy=session_policy(stage))
+        written = (tmp_path / ".argo_gemini_policy.toml").read_text(encoding="utf-8")
+        assert written == _GEMINI_POLICY_NETWORK
+        assert "google_web_search" not in written and "web_fetch" not in written
+        assert "run_shell_command" in written   # shell stays denied even here
+    for stage in ("ingest", "recon", "audit", "validate", "report", "remediate", "verify"):
+        _invoke(r, tmp_path, policy=session_policy(stage))
+        assert (tmp_path / ".argo_gemini_policy.toml").read_text(encoding="utf-8") == _GEMINI_POLICY_OFFLINE
+    r.ledger.close()
+
+
+# --------------------------------------------------------------- envelope parsing (real capture)
+def test_parser_over_real_envelope_sums_all_stats_models():
+    """The real capture has TWO entries in stats.models (an unpinned call -- omitting -m triggers
+    an extra internal 'utility_router' model pick, confirmed live 2026-08-17): gemini-3.1-flash-lite
+    (prompt=2929, candidates=38) and gemini-3.5-flash (prompt=9373, candidates=1). Argo always pins
+    -m so this specific shape is rare in practice, but parse_envelope must not assume exactly one
+    entry -- this fixture organically exercises that without a synthetic multi-model construction."""
+    r = GeminiRunner.__new__(GeminiRunner)  # parse_envelope doesn't touch self; skip __init__
+    res = r.parse_envelope(REAL, model="gemini-3.5-flash", prompt_sha256="h", work_dir=Path("."))
+    assert res.text == "OK"
+    assert res.input_tokens == 2929 + 9373
+    assert res.output_tokens == 38 + 1
+    assert res.session_id == "30fae387-c78c-4f36-8976-48caced18ed5"
+    assert res.is_error is False
+    assert res.cost_usd > 0
+
+
+def test_parser_error_shape():
+    """Real observed error envelope shape (a 429 quota error, captured live 2026-08-17): a clean
+    {"error": {type, message, code}} JSON on stdout alongside exit 1 -- NOT the 'no output at all'
+    shape (that's handled in _invoke, before parse_envelope ever sees it)."""
+    raw = {"session_id": "s2", "error": {"type": "Error",
+           "message": "You exceeded your current quota, please check your plan and billing "
+                      "details. ... Please retry in 23.229712457s.", "code": 1}, "_exit_code": 1}
+    r = GeminiRunner.__new__(GeminiRunner)
+    res = r.parse_envelope(raw, model="gemini-3.1-pro", prompt_sha256="h", work_dir=Path("."))
+    assert res.is_error is True
+    assert "exceeded your current quota" in res.text
+    assert res.stop_reason == "exit_1"
+    assert _classify_failure_text(res.text) == "rate_limited"   # "quota" hint, real observed wording
+
+
+# --------------------------------------------------------------- heuristic refusal -> moderation bridge
+def test_looks_like_gemini_refusal_requires_cooccurrence():
+    real_observed = ("I cannot provide a command or instructions intended to destroy filesystems "
+                     "or disrupt production servers as part of an unauthorized attack.")
+    assert _looks_like_gemini_refusal(real_observed) is True
+    # "I cannot provide X" alone (no safety-flavored word) is a mundane, non-refusal reply --
+    # must NOT false-positive, or a normal clarifying answer would get treated as a moderation flag.
+    mundane = "I cannot provide the exact commit hash without more context, can you clarify?"
+    assert _looks_like_gemini_refusal(mundane) is False
+
+
+def test_parse_envelope_bridges_soft_refusal_to_moderation_flagged():
+    """THE bridge test: a soft refusal arrives as a NORMAL SUCCESS envelope (confirmed live
+    2026-08-17 -- no structured finishReason field is surfaced by the CLI). parse_envelope must
+    still force is_error=True and embed a marker the SHARED _classify_failure_text can match, so
+    _run_attempt's generic error path (and run()'s neutral-register retry) fires exactly like it
+    does for Claude's/Codex's own fixed refusal signatures -- proving the bridge actually plugs
+    into the unmodified fallback machinery, not just that the heuristic itself works standalone."""
+    raw = {"session_id": "s3", "response": (
+        "I cannot provide a command or instructions intended to destroy filesystems or disrupt "
+        "production servers as part of an unauthorized attack."), "stats": {"models": {}}}
+    r = GeminiRunner.__new__(GeminiRunner)
+    res = r.parse_envelope(raw, model="m", prompt_sha256="h", work_dir=Path("."))
+    assert res.is_error is True
+    assert _GEMINI_MODERATION_MARKER in res.text
+    assert _classify_failure_text(res.text) == "moderation_flagged"
+
+
+def test_parse_envelope_normal_success_is_not_flagged():
+    raw = {"session_id": "s4", "response": "Findings written to SECURITY_FINDINGS__auth.json.",
+           "stats": {"models": {}}}
+    r = GeminiRunner.__new__(GeminiRunner)
+    res = r.parse_envelope(raw, model="m", prompt_sha256="h", work_dir=Path("."))
+    assert res.is_error is False
+
+
+# --------------------------------------------------------------- exit codes (_invoke)
+def test_invoke_exit_42_invalid_input_is_not_retryable(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    monkeypatch.setattr(r, "_exec", lambda *a, **k: _FakeProc("", "bad prompt", 42))
+    with pytest.raises(RunnerError) as exc_info:
+        _invoke(r, tmp_path)
+    assert exc_info.value.retryable is False
+    r.ledger.close()
+
+
+def test_invoke_exit_53_turn_limit_is_retryable_new_kind(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+    monkeypatch.setattr(r, "_exec", lambda *a, **k: _FakeProc("", "turn limit reached", 53))
+    with pytest.raises(RunnerError) as exc_info:
+        _invoke(r, tmp_path)
+    assert exc_info.value.retryable is True
+    assert exc_info.value.failure_kind == "turn_limit_exceeded"
+    r.ledger.close()
+
+
+def test_invoke_timeout_is_retryable(tmp_path, monkeypatch):
+    r = _runner(tmp_path)
+
+    def _boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd=["gemini"], timeout=5)
+
+    monkeypatch.setattr(r, "_exec", _boom)
+    with pytest.raises(RunnerError) as exc_info:
+        _invoke(r, tmp_path)
+    assert exc_info.value.retryable is True
+    assert exc_info.value.failure_kind == "timeout"
+    r.ledger.close()
+
+
+def test_invoke_no_stdout_startup_crash_is_retryable_unknown(tmp_path, monkeypatch):
+    """Real observed shape of a FatalSandboxError-style startup crash (confirmed live: nothing on
+    stdout, everything on stderr, exit 1) -- must not be confused with the exit-42/53 special cases."""
+    r = _runner(tmp_path)
+    monkeypatch.setattr(r, "_exec", lambda *a, **k: _FakeProc("", "some unrelated startup error", 1))
+    with pytest.raises(RunnerError) as exc_info:
+        _invoke(r, tmp_path)
+    assert exc_info.value.retryable is True
+    assert exc_info.value.failure_kind == "unknown_retryable"
+    r.ledger.close()
+
+
+# --------------------------------------------------------------- model tiering (config)
+def test_model_for_gemini_per_stage_tiering():
+    cfg = PipelineConfig(runner="gemini")
+    assert cfg.model_for("recon") == GEMINI_PRO
+    assert cfg.model_for("audit") == GEMINI_FLASH
+    assert cfg.model_for("verify") == GEMINI_PRO
+
+
+def test_gemini_model_override_and_calibrated():
+    cfg = PipelineConfig(runner="gemini").with_stage_model("audit", GEMINI_PRO)
+    assert cfg.model_for("audit") == GEMINI_PRO
+    assert cfg.model_for("recon") == GEMINI_PRO   # untouched stages unaffected
+    assert cfg.calibrated().model_for("audit") == GEMINI_PRO
+
+
+def test_for_smoke_primes_gemini_stage_models_too():
+    cfg = PipelineConfig(runner="gemini").for_smoke()
+    assert cfg.gemini_stage_models["audit"] == GEMINI_FLASH_LITE
+    assert cfg.gemini_stage_models["recon"] == GEMINI_FLASH
+
+
+def test_gemini_cost_estimate():
+    assert estimate_cost_usd(GEMINI_PRO, 1_000_000, 0) == 2.00
+    assert estimate_cost_usd(GEMINI_FLASH_LITE, 0, 1_000_000) == 1.50
+
+
+# --------------------------------------------------------------- dispatch
+def test_build_runner_dispatches_gemini(tmp_path):
+    r = build_runner(PipelineConfig(runner="gemini"), Ledger(tmp_path / "l.sqlite"))
+    assert isinstance(r, GeminiRunner)
+    r.ledger.close()
+
+
+# --------------------------------------------------------------- API + CLI passthrough
+def test_api_and_cli_gemini_config_passthrough(tmp_path):
+    # API: RunConfig -> PipelineConfig mapping
+    from server.jobs import JobManager
+    from server.schemas import RunConfig, RunRequest
+    jm = JobManager(PipelineConfig(runs_dir=tmp_path / "runs", ledger_path=tmp_path / "l.sqlite"))
+    cfg = jm._config_for(RunRequest(brief="b", repo="r", config=RunConfig(
+        runner="gemini", gemini_model=GEMINI_PRO, gemini_api_key="sk-test")))
+    assert cfg.runner == "gemini" and cfg.gemini_api_key == "sk-test"
+    assert all(m == GEMINI_PRO for m in cfg.gemini_stage_models.values())
+    # CLI: _build_config passthrough
+    from argo.cli import _build_config
+    c2 = _build_config("gemini", None, False, None, 3, tmp_path / "runs", "happy",
+                       gemini_model=GEMINI_FLASH, gemini_api_key="sk-test-2",
+                       gemini_accounts="k1,k2")
+    assert c2.runner == "gemini" and c2.gemini_api_key == "sk-test-2"
+    assert all(m == GEMINI_FLASH for m in c2.gemini_stage_models.values())
+    assert c2.gemini_accounts == ["k1", "k2"]
+    # --gemini-model applies BEFORE --calibration, so calibration can still bump audit on top
+    c3 = _build_config("gemini", None, True, None, 3, tmp_path / "runs", "happy",
+                       gemini_model=GEMINI_FLASH_LITE)
+    assert c3.model_for("audit") == GEMINI_PRO           # calibration won
+    assert c3.model_for("recon") == GEMINI_FLASH_LITE     # untouched stage kept the flat override


### PR DESCRIPTION
## Summary
- Adds a third swappable backend (`GeminiRunner`, `--runner gemini`) alongside Claude Code and Codex, tiered per stage like Claude instead of flat like Codex — fully composable into the existing fallback chain / multi-account resilience with zero changes to `FallbackRunner`.
- Design verified empirically against a real `gemini` CLI (v0.49.0) before writing any command/parser code — stdin-only prompt delivery, `--skip-trust` requirement, real envelope shape, and moderation handling all differ from what the docs alone suggested. Guardrails use the Policy Engine (Claude's named-tool-denylist dialect) rather than `--sandbox`, which has a hard, unreliable Docker/Podman dependency.
- Repo-write safety is unaffected by that choice — it already comes from `ingest`'s backend-agnostic chmod, not sandboxing.

## Test plan
- [x] `pytest tests/ -q` — 410 passed, 2 skipped (mock runner, zero token cost)
- [x] Real `--smoke --runner gemini` run on the bundled fixtures — genuine `REPORT.md` produced; `ingest`/`audit`/`sca` came back `is_error: false` (3 real sessions, $0.0755); `recon` hit a real free-tier daily quota exhaustion (an external constraint, not a code defect) and degraded gracefully via Argo's existing, Gemini-agnostic partial-artifact recovery. Full honest writeup in `docs/backends.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKGXWqUr7or13ZN8Mx9Pdm