### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ particular while the version stays `0.y.z`.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-17
+
 ### Added
 
 - **Cross-backend benchmark**: `argo bench-cross --suite DIR --backends headless,codex,gemini

--- a/argo/__init__.py
+++ b/argo/__init__.py
@@ -14,4 +14,4 @@ Hard guardrails are enforced in code (not just in prompts):
   * every LLM call is logged (prompt hash, model, token cost).
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argo-audit"
-version = "0.4.0"
+version = "0.5.0"
 description = "Argo — AI source-static security-audit pipeline for bug-bounty programs"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Version bump 0.4.0 -> 0.5.0 (MINOR, per docs/releasing.md — additive cross-backend benchmark, no breaking change).
- Moves CHANGELOG [Unreleased] into a dated 0.5.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKGXWqUr7or13ZN8Mx9Pdm