### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ particular while the version stays `0.y.z`.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-18
+
 ### Added
 
 - **Web UI: Gemini as a full runner option.** New Run's runner selector and Settings' default-runner

--- a/argo/__init__.py
+++ b/argo/__init__.py
@@ -14,4 +14,4 @@ Hard guardrails are enforced in code (not just in prompts):
   * every LLM call is logged (prompt hash, model, token cost).
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argo-audit"
-version = "0.5.0"
+version = "0.6.0"
 description = "Argo — AI source-static security-audit pipeline for bug-bounty programs"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Cuts v0.6.0 — MINOR per docs/releasing.md (additive web-UI capability, no breaking change): Gemini support in the web UI plus cross-backend/refusal-probe read views, both merged in #23.

- Bumps `pyproject.toml` / `argo/__init__.py`
- Moves `CHANGELOG.md`'s `[Unreleased]` section into `## [0.6.0] - 2026-08-18`

## Test plan

- [x] CI green on #23 (the content this release ships)
- [ ] CI green on this PR
- [ ] Tag `v0.6.0` on the merge commit + publish GitHub Release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)