### PR TITLE
fix: correct README headline stats — Fleece status != public visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Not a benchmark score — pull requests, published advisories, and a CVE, on real open-source projects.
 
-**31** projects audited and disclosed · **35** public PRs · **65** already resolved · **93% real-world accuracy**\*
+**11** projects audited and disclosed · **42** public PRs · **38** already resolved · **93% real-world accuracy**\*
 
 | Project | Stars | Severity | Result |
 |---|---:|---|---|
@@ -21,6 +21,7 @@ Not a benchmark score — pull requests, published advisories, and a CVE, on rea
 | [PocketBase](https://github.com/pocketbase/pocketbase) | 61k★ | High (8.7) | [Advisory published](https://github.com/pocketbase/pocketbase/security/advisories/GHSA-84vh-m24q-wjjx), reporter credited |
 | [LiveKit](https://github.com/livekit/livekit) | 20k★ | Critical + High | 13 of 24 findings fixed, credited on their [Security Hall of Fame](https://livekit.com/security/hall-of-fame) |
 | [coturn](https://github.com/coturn/coturn) | 14k★ | Medium | Real CVE assigned: [CVE-2026-73213](https://github.com/coturn/coturn/security/advisories/GHSA-4v97-rxjj-4f99) |
+| [ntfy](https://github.com/binwiederhier/ntfy) | 33k★ | High | Broken access control on revoked subscriptions, [PR open](https://github.com/binwiederhier/ntfy/pull/1845) |
 
 **[See every disclosed finding →](https://gigioneggiando.github.io/argo/)**
 


### PR DESCRIPTION
## Summary

Corrects the headline disclosure stats shipped in the last README update (part of #23/v0.6.0). Those numbers (31 projects/35 PRs/65 resolved) were computed from Fleece's own status fields as a proxy for public visibility — this session's rigorous per-project `gh api` verification (advisory publish state, real PR merge state, credits) found that's not a reliable signal: a GHSA opened via private vulnerability reporting can sit in `triage` for months before a maintainer actually publishes it, and Fleece doesn't distinguish that from a real public artifact.

Checked every candidate beyond the existing 10 live on the site (18 repos total, individually verified via `gh api`/`gh pr list`) — only one, **ntfy**, has a genuine new public artifact (PR #1845, open, maintainer replied positively). Everything else is still private/draft/triage.

Corrected to: **11** projects, **42** public PRs, **38** already resolved — which now reconciles exactly with the live gh-pages site's own row-level counts (verified those are accurate too; only the README's derived aggregate was wrong). 93% accuracy is untouched — it's a different, still-valid metric (counts private maintainer acknowledgement as a real verdict on purpose).

## Test plan

- [x] Recomputed the row-level counts by grep across `gh-pages`'s live `index.html` (17 merged + 21 fixed + 3 open = 41 existing PRs, unchanged) and added ntfy's 1 open PR = 42
- [x] Independently re-verified ntfy PR #1845 is still open, not merged, via `gh api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)