### PR TITLE
fix: resolve session-limit reset hint to an absolute timestamp at capture time

### DIFF
--- a/argo/cli.py
+++ b/argo/cli.py
@@ -227,6 +227,9 @@ def _resume_config(run: str, runs_dir: Path) -> PipelineConfig:
 
 
 def _failed_retry_after(status: dict | None) -> str | None:
+    """The absolute, unambiguous ISO-8601 timestamp to actually schedule against. See
+    progress.ProgressReporter.fail_stage's docstring for why this must never be a raw human hint
+    re-parsed against a later "now"."""
     if not status:
         return None
     for st in status.get("stages") or []:
@@ -235,10 +238,22 @@ def _failed_retry_after(status: dict | None) -> str | None:
     return status.get("retry_after")
 
 
-def _sleep_until_retry_after(retry_after: str, *, max_wait: timedelta) -> None:
+def _failed_retry_after_hint(status: dict | None) -> str | None:
+    """The original human-readable hint (e.g. "1:50pm (Europe/Kyiv)"), display-only -- never
+    parsed for scheduling. Falls back to None on runs written before this field existed."""
+    if not status:
+        return None
+    for st in status.get("stages") or []:
+        if isinstance(st, dict) and st.get("state") == "failed" and st.get("retry_after_hint"):
+            return st.get("retry_after_hint")
+    return status.get("retry_after_hint")
+
+
+def _sleep_until_retry_after(retry_after: str, *, max_wait: timedelta, display: str | None = None) -> None:
     target = parse_retry_after(retry_after)
     if target is None:
         return
+    shown = display or retry_after
     now = datetime.now(timezone.utc).astimezone(target.tzinfo)
     wake = target + timedelta(seconds=60)
     if wake <= now:
@@ -246,13 +261,13 @@ def _sleep_until_retry_after(retry_after: str, *, max_wait: timedelta) -> None:
     wait_for = wake - now
     if wait_for > max_wait:
         raise typer.BadParameter(
-            f"retry_after {retry_after!r} is {wait_for} away, beyond --max-wait {max_wait}")
+            f"retry_after {shown!r} is {wait_for} away, beyond --max-wait {max_wait}")
     while True:
         now = datetime.now(timezone.utc).astimezone(wake.tzinfo)
         remaining = wake - now
         if remaining.total_seconds() <= 0:
             return
-        typer.echo(f"[resume] waiting {remaining} until retry_after={retry_after!r}")
+        typer.echo(f"[resume] waiting {remaining} until retry_after={shown!r}")
         time.sleep(min(300, max(1, remaining.total_seconds())))
 
 
@@ -561,11 +576,13 @@ def resume(
     cfg = _resume_config(run, runs_dir)
     status = read_status(Path(cfg.runs_dir) / run)
     retry_after = _failed_retry_after(status)
+    retry_after_hint = _failed_retry_after_hint(status)
     target = parse_retry_after(retry_after) if retry_after else None
     if target is not None and target > datetime.now(timezone.utc).astimezone(target.tzinfo):
         if not wait:
-            raise typer.BadParameter(f"resume again after {retry_after}")
-        _sleep_until_retry_after(retry_after, max_wait=_parse_duration(max_wait))
+            raise typer.BadParameter(f"resume again after {retry_after_hint or retry_after}")
+        _sleep_until_retry_after(retry_after, max_wait=_parse_duration(max_wait),
+                                 display=retry_after_hint)
     ctx = build_context(cfg, run)
     summary = _run_with_resume_hint(lambda: resume_pipeline(ctx), ctx)
     _emit(summary)

--- a/argo/orchestrator.py
+++ b/argo/orchestrator.py
@@ -242,10 +242,20 @@ def _run_stage_sequence(ctx: RunContext, stage_fns: list[tuple[str, object]],
             except Exception as exc:
                 wait_s = _auto_retry_wait_seconds(exc) if attempt < _MAX_STAGE_AUTO_RETRIES else None
                 if wait_s is None:
+                    hint = getattr(exc, "retry_after", None)
+                    # Resolve to an absolute timestamp NOW, while "now" is unambiguous -- a later
+                    # `argo resume --wait` may re-read this hint hours or days after this write, and
+                    # re-parsing a bare time-of-day string like "1:50pm (Europe/Kyiv)" against a much
+                    # later "now" is genuinely ambiguous (has that same clock time already passed
+                    # today, meaning it must mean tomorrow -- or did we just cross it a few minutes
+                    # ago, meaning it's already due?). An absolute ISO timestamp has no such
+                    # ambiguity. See progress.ProgressReporter.fail_stage's docstring.
+                    resolved = parse_retry_after(hint)
                     reporter.fail_stage(
                         name,
                         f"{type(exc).__name__}: {exc}",
-                        retry_after=getattr(exc, "retry_after", None),
+                        retry_after=resolved.isoformat() if resolved else None,
+                        retry_after_hint=hint,
                     )
                     raise
                 attempt += 1

--- a/argo/progress.py
+++ b/argo/progress.py
@@ -39,6 +39,8 @@ class ProgressReporter:
         self._state = str(initial_status.get("state") or "starting") if initial_status else "starting"
         self._error: Optional[str] = initial_status.get("error") if initial_status else None
         self._retry_after: Optional[str] = initial_status.get("retry_after") if initial_status else None
+        self._retry_after_hint: Optional[str] = (
+            initial_status.get("retry_after_hint") if initial_status else None)
         self._started_at = (initial_status.get("started_at") if initial_status else None) or _now()
         self._stage_state = {s: {"name": s, "state": "pending"} for s in self.stages}
         if initial_status:
@@ -57,6 +59,7 @@ class ProgressReporter:
             self._state = "running"
             self._error = None
             self._retry_after = None
+            self._retry_after_hint = None
             self._write()
 
     def start_stage(self, stage: str) -> None:
@@ -67,9 +70,11 @@ class ProgressReporter:
             st.pop("ended_at", None)
             st.pop("error", None)
             st.pop("retry_after", None)
+            st.pop("retry_after_hint", None)
             self._state = "running"
             self._error = None
             self._retry_after = None
+            self._retry_after_hint = None
             self._write()
 
     def finish_stage(self, stage: str) -> None:
@@ -79,9 +84,18 @@ class ProgressReporter:
             st["ended_at"] = _now()
             st.pop("error", None)
             st.pop("retry_after", None)
+            st.pop("retry_after_hint", None)
             self._write()
 
-    def fail_stage(self, stage: str, error: str, retry_after: str | None = None) -> None:
+    def fail_stage(self, stage: str, error: str, retry_after: str | None = None,
+                    retry_after_hint: str | None = None) -> None:
+        """``retry_after`` is an absolute, unambiguous ISO-8601 timestamp (resolved by the caller
+        at the moment of failure, when "now" is unambiguous) -- never a raw human hint like "1:50pm
+        (Europe/Kyiv)". A ``resume --wait`` invocation can run arbitrarily long after this write, so
+        re-interpreting a bare time-of-day string against a LATER "now" is genuinely ambiguous (is
+        1:50pm still today, or did we roll past it and it means tomorrow?) in a way an absolute
+        timestamp never is. ``retry_after_hint`` keeps the original human text for display only --
+        it must never be parsed for scheduling."""
         with self._lock:
             st = self._stage_state.setdefault(stage, {"name": stage, "state": "pending"})
             st["state"] = "failed"
@@ -91,9 +105,14 @@ class ProgressReporter:
                 st["retry_after"] = retry_after
             else:
                 st.pop("retry_after", None)
+            if retry_after_hint:
+                st["retry_after_hint"] = retry_after_hint
+            else:
+                st.pop("retry_after_hint", None)
             self._state = "failed"
             self._error = error
             self._retry_after = retry_after
+            self._retry_after_hint = retry_after_hint
             self._write()
 
     def complete(self) -> None:
@@ -101,6 +120,7 @@ class ProgressReporter:
             self._state = "completed"
             self._error = None
             self._retry_after = None
+            self._retry_after_hint = None
             self._write()
 
     def cancelled(self) -> None:
@@ -116,6 +136,7 @@ class ProgressReporter:
             self._state = "failed"
             self._error = error
             self._retry_after = None
+            self._retry_after_hint = None
             self._write()
 
     # -- snapshot -------------------------------------------------------------------
@@ -136,6 +157,7 @@ class ProgressReporter:
             "cost_usd": round(cost, 6),
             "error": self._error,
             "retry_after": self._retry_after,
+            "retry_after_hint": self._retry_after_hint,
             "started_at": self._started_at,
             "updated_at": _now(),
         }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ real calls).
 
 ```bash
 pip install -r requirements.txt
-python -m pytest tests/ -q          # 432 tests (incl. the HTTP API + UI serving on the mock runner)
+python -m pytest tests/ -q          # 433 tests (incl. the HTTP API + UI serving on the mock runner)
 ```
 
 `pytest.ini` pins `--basetemp=.pytest_tmp` so the read-only repo copies the pipeline creates do

--- a/tests/test_orchestrator_retry.py
+++ b/tests/test_orchestrator_retry.py
@@ -119,6 +119,39 @@ def test_a_reset_hint_too_far_out_is_not_auto_waited_for(tmp_path, monkeypatch):
     assert calls["n"] == 1
 
 
+def test_persisted_retry_after_is_an_absolute_timestamp_not_a_raw_hint(tmp_path, monkeypatch):
+    """Regression test for a real bug caught live (Argo self-audit session, 2026-08-18): a raw
+    human hint like "1:50pm (Europe/Kyiv)" written verbatim into status.json's retry_after is
+    ambiguous when `argo resume --wait` re-parses it later -- if resume runs even a few minutes
+    AFTER that clock time has already passed today, parse_retry_after's "already past -> must mean
+    tomorrow" fallback kicks in and wrongly adds a full day, turning a ~1h wait into a ~24h one.
+    The fix: resolve the hint to an absolute ISO timestamp at the moment of failure (when "now" is
+    unambiguous), and persist THAT -- re-parsing an ISO timestamp is never ambiguous. The raw hint
+    is kept separately, display-only, in retry_after_hint."""
+    _never_sleep(monkeypatch)
+    hint = "1:50pm (Europe/Kyiv)"
+
+    def hits_session_limit():
+        raise RunnerError("session limit", retryable=True, failure_kind="rate_limited",
+                          retry_after=hint)
+
+    ctx = _ctx(tmp_path)
+    reporter = _reporter(ctx)
+    with pytest.raises(RunnerError):
+        _run_stage_sequence(ctx, [("stageA", hits_session_limit)], reporter)
+
+    status = reporter.snapshot()
+    assert status["retry_after_hint"] == hint
+    # Must be an absolute, parseable ISO timestamp -- not the raw hint string itself.
+    assert status["retry_after"] != hint
+    persisted = datetime.fromisoformat(status["retry_after"])
+    # Re-parsing that persisted value later (simulating a delayed `resume --wait`) must return the
+    # SAME instant every time, regardless of how much later "now" has moved on -- unlike the raw
+    # hint, which orch.parse_retry_after would reinterpret differently depending on the clock.
+    much_later = persisted + timedelta(days=3)
+    assert orch.parse_retry_after(status["retry_after"], now=much_later) == persisted
+
+
 def test_a_cancelled_run_is_never_retried(tmp_path, monkeypatch):
     _never_sleep(monkeypatch)
 


### PR DESCRIPTION
## Summary

Found live during a real self-audit run of Argo's own core package (`argo/`, first end-to-end test of the resume-after-session-limit flow with a real Claude backend, no `--fallback`). Claude hit its session limit mid-recon ("resets 1:50pm (Europe/Kyiv)"). `argo resume --run ID --wait` ran a few minutes AFTER that reset had already passed, and incorrectly computed a ~24h wait instead of resuming immediately — because it re-parsed the raw human hint text against a NEW "now" at resume time, and `parse_retry_after`'s "already past → must mean tomorrow" fallback (correct for freshly interpreting an API error) misfires when re-applied to an old hint whose target has already legitimately arrived.

**Fix**: resolve the hint to an absolute ISO-8601 timestamp the moment a stage genuinely fails (`orchestrator.py`), when "now" is unambiguous, and persist that instead of the raw text. Re-parsing an absolute timestamp is never ambiguous regardless of how much later `resume` runs. The original human text is kept separately (`retry_after_hint`, display-only, never re-parsed).

## Test plan

- [x] `python -m pytest tests/ -q` — 431 passed, 2 skipped (433 total, +1 new)
- [x] New regression test (`test_persisted_retry_after_is_an_absolute_timestamp_not_a_raw_hint`) asserting the persisted value reparses identically 3 days later
- [x] Standalone before/after script reproducing the exact real incident's Kyiv timestamps
- [x] End-to-end: migrated the real stalled run's `status.json` to the new shape and confirmed `argo resume --wait` correctly recognized the reset had passed and resumed recon immediately, instead of trying to sleep ~24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)