### PR TITLE
audit: retry a focus whose session never started, instead of abandoning it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,21 @@ __pycache__/
 build/
 dist/
 .eggs/
+
+# Scratch output from manual audit runs — never part of the repo
+*_audit.log
+*_audit.err.log
+*_audit.out.log
+*_verify.log
+*_variant_check.log
+
+# One-off PoC scratch from manual verification (cookie jars, API dumps from local test instances)
+/a2.txt
+/a3.txt
+/attack.txt
+/cj.txt
+/adm.json
+/appnew.json
+/org.json
+/org2.json
+/pocapp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ particular while the version stays `0.y.z`.
 
 ## [Unreleased]
 
+### Fixed
+- **Audit: a focus whose session never started is now retried once instead of abandoned.**
+  Both backends can fail inside the same minute (a transient limit, `exit_1` with zero
+  tokens and no partial artifact) and the stage used to drop that focus permanently — a run
+  could finish clean having audited one of three focus areas, which makes its finding count a
+  property of when it ran rather than of the target. Retried once after `audit_retry_delay_s`
+  (90 s), controlled by `audit_retry_passes` (0 restores the old behaviour). Only SESSION
+  failures retry: a malformed or schema-invalid findings file is a result and stands, because
+  re-rolling until the model emits something parseable would be selecting on the output.
+
+
 ### Added
 
 - Web UI **Overview dashboard** (the new landing at `#/`): KPI stat tiles plus theme-aware,

--- a/argo/config.py
+++ b/argo/config.py
@@ -254,6 +254,13 @@ class PipelineConfig:
     # session, re-invoke it to find what was MISSED — uncovered variant-family members, unverified
     # invariants, 🟡 rows not promoted. Each pass appends only NEW findings; passes stop early when
     # a pass yields nothing new (loop-until-dry, capped). 0 disables. Trades tokens for recall.
+    # A focus whose SESSION never produced anything is lost work, not a result: both backends
+    # can blip inside the same minute and cost a whole focus permanently, which leaves one
+    # target audited on fewer focuses than the rest. Retried once by default, after a pause
+    # long enough for a short backend backoff to clear. Set passes to 0 to restore the old
+    # abandon-on-failure behaviour.
+    audit_retry_passes: int = 1
+    audit_retry_delay_s: int = 90
     audit_critic_passes: int = 1
     # Software-composition analysis: read dependency manifests and flag pinned versions with known
     # advisories. Emits a synthetic `dependencies` focus that joins the normal validate+report flow.

--- a/argo/stages/audit.py
+++ b/argo/stages/audit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -165,7 +166,15 @@ def _normalize_findings_doc(raw_doc: dict, ctx: RunContext, scope, slug: str):
     return doc, repaired_ids, unrecoverable, coerced
 
 
-def _audit_one(ctx: RunContext, scope, prompt_path: Path) -> tuple[str, Path | None, str | None]:
+def _audit_one(ctx: RunContext, scope, prompt_path: Path
+               ) -> tuple[str, Path | None, str | None, bool]:
+    """Audit one focus. Returns (slug, findings_path, error, retryable).
+
+    ``retryable`` is True only when the SESSION itself never produced anything -- a transient
+    backend failure, not a bad answer. A malformed or schema-invalid findings file is a real
+    result and is never retried: re-rolling until the model emits something parseable would be
+    selecting on the output.
+    """
     slug = prompt_path.stem  # e.g. "audit_p1_full_scope"
     prompt_text = prompt_path.read_text(encoding="utf-8")
 
@@ -216,16 +225,16 @@ def _audit_one(ctx: RunContext, scope, prompt_path: Path) -> tuple[str, Path | N
         partial = True
         files = sorted(work.glob("SECURITY_FINDINGS__*.json"))
         if not files:
-            return slug, None, f"session failed, no partial artifact ({exc})"
+            return slug, None, f"session failed, no partial artifact ({exc})", True
         _log(f"{slug}: session failed ({exc}); recovered partial artifact from scratch dir")
     if not files:
-        return slug, None, "no findings JSON produced"
+        return slug, None, "no findings JSON produced", True
     # Prefer the exactly-named file; else take the first JSON found (glob fallback).
     chosen = next((f for f in files if f.name == findings_filename), files[0])
     try:
         raw_doc = json.loads(chosen.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError as exc:
-        return slug, None, f"findings file is not valid JSON: {exc}"
+        return slug, None, f"findings file is not valid JSON: {exc}", False
 
     doc, repaired_ids, unrecoverable, coerced = _normalize_findings_doc(raw_doc, ctx, scope, slug)
     if repaired_ids:
@@ -236,18 +245,18 @@ def _audit_one(ctx: RunContext, scope, prompt_path: Path) -> tuple[str, Path | N
     if coerced:
         _log(f"{slug}: coerced structured fields to strings in {coerced} finding(s)")
     if not doc.get("findings"):
-        return slug, None, "no schema-conformant findings after normalization"
+        return slug, None, "no schema-conformant findings after normalization", False
     try:
         validate_findings(doc, ctx.assets_dir)     # final gate on the normalized doc
     except SchemaValidationError as exc:
-        return slug, None, f"findings still invalid after normalization: {exc}"
+        return slug, None, f"findings still invalid after normalization: {exc}", False
 
     out = ctx.findings_dir / f"{slug}.json"
     atomic_write_json(out, doc)
     _collect_variant_log(ctx, slug, work)
     n = len(doc.get("findings", []))
     _log(f"{slug}: {n} finding(s){' [partial session]' if partial else ''}")
-    return slug, out, None
+    return slug, out, None, False
 
 
 def _collect_variant_log(ctx: RunContext, slug: str, work: Path) -> Path | None:
@@ -396,15 +405,40 @@ def run(ctx: RunContext) -> list[Path]:
 
     max_workers = max(1, min(ctx.config.max_parallel_audits, len(launch)))
     produced: dict[str, Path] = {}   # slug -> focus findings doc
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        futures = {ex.submit(_audit_one, ctx, scope, p): p for p in launch}
-        for fut in as_completed(futures):
-            slug, path, err = fut.result()
-            if err:
-                _log(f"{slug}: SKIPPED ({err})")
-            elif path is not None:
-                results.append(path)
-                produced[slug] = path
+
+    def _pass(paths: list[Path], attempt: int) -> list[Path]:
+        """Run a set of focuses; return the ones whose SESSION failed and may be retried."""
+        retryable: list[Path] = []
+        workers = max(1, min(ctx.config.max_parallel_audits, len(paths)))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(_audit_one, ctx, scope, p): p for p in paths}
+            for fut in as_completed(futures):
+                slug, path, err, can_retry = fut.result()
+                if err:
+                    _log(f"{slug}: {'FAILED' if can_retry else 'SKIPPED'} ({err})"
+                         + (f" [attempt {attempt}]" if attempt > 1 else ""))
+                    if can_retry:
+                        retryable.append(futures[fut])
+                elif path is not None:
+                    results.append(path)
+                    produced[slug] = path
+        return retryable
+
+    # A focus whose session never started is lost work, not a result: both backends can blip
+    # inside the same minute and cost a whole focus permanently, leaving one target audited on
+    # fewer focuses than the rest and making their finding counts incomparable. Retried once,
+    # after a pause long enough for a short backend backoff to clear. Only SESSION failures are
+    # retried (see _audit_one); a malformed answer is a result and stands.
+    failed = _pass(launch, 1)
+    if failed and ctx.config.audit_retry_passes > 0:
+        delay = ctx.config.audit_retry_delay_s
+        _log(f"{len(failed)} focus(es) failed at session level: {[p.stem for p in failed]}; "
+             f"retrying once in {delay}s")
+        time.sleep(delay)
+        still = _pass(failed, 2)
+        if still:
+            _log(f"still failing after the retry: {[p.stem for p in still]} — these focuses are "
+                 f"absent from this run's coverage")
 
     # Completeness-critic round: per focus, re-pass to surface missed variant-family members /
     # unverified invariants. Appends new findings in place. Cost-gated; parallel across focuses.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,8 @@ The runner re-applies these on every call, so a stage cannot widen them. See
 | `max_parallel_audits` | `--parallel` | concurrency cap for Stage 3 / Stage 4 fan-out (default 3) |
 | `max_focuses` | (set by `--smoke`) | cap the audit fan-out to the first N focuses; truncation is logged |
 | `audit_critic_passes` | `--critic-passes` | completeness-critic re-passes per audit focus (depth lever; default 1, 0 disables; loops until a pass adds nothing) |
+| `audit_retry_passes` | — | retry a focus whose SESSION never produced anything (default 1, 0 disables). Only session failures retry; a malformed or schema-invalid answer is a result and stands. |
+| `audit_retry_delay_s` | — | pause before that retry (default 90 s), long enough for a short backend backoff to clear |
 | `validate_batch_size` | — | findings per adversarial-validation session (default 8). Collapses the one-session-per-finding fan-out — the main driver of session/rate-limit cost — with no precision loss (each finding is judged independently in the shared session). `1` = legacy per-finding path (also used by chat/B1 re-validate). |
 | `corroborate_batch_size` | — | survivors per corroboration session (default 8), same batching rationale for the networked docs/VCS cross-check. |
 | `sca_enabled` | `--sca / --no-sca` | run the software-composition (dependency) stage between audit and validate (default on) |

--- a/tests/test_audit_retry.py
+++ b/tests/test_audit_retry.py
@@ -1,0 +1,122 @@
+"""Audit focus retry — a session that never started is lost work, not a result.
+
+Regression cover for a real coverage loss (Study C run 01b, 2026-09-05): both codex backends
+blipped inside the same minute, two of three audit focuses returned `exit_1` with zero tokens and
+no partial artifact, and the stage abandoned them. The run finished clean with one third of the
+planned audit surface covered — and a target audited on one focus is not comparable with a target
+audited on three, so the finding count stops being a property of the target.
+
+The line these tests hold: **session failures are retried, answers are not.** Re-rolling a focus
+until the model emits something parseable would be selecting on the output.
+"""
+
+import argo.stages.audit as audit_stage
+from argo.orchestrator import do_audit, do_ingest, do_recon
+
+from conftest import BRIEF, REPO
+
+
+def _prepare(env, **cfg):
+    ctx = env(**cfg)
+    do_ingest(ctx, BRIEF, str(REPO))
+    do_recon(ctx)
+    return ctx
+
+
+def _fake_audit_one(script, calls, real):
+    """Wrap _audit_one so the first N attempts per slug fail as scripted."""
+    def _inner(ctx, scope, prompt_path):
+        slug = prompt_path.stem
+        calls.append(slug)
+        remaining = script.get(slug, 0)
+        if remaining > 0:
+            script[slug] = remaining - 1
+            return slug, None, "session failed, no partial artifact (simulated)", True
+        return real(ctx, scope, prompt_path)
+    return _inner
+
+
+def test_a_session_failure_is_retried_once_and_can_succeed(env, monkeypatch):
+    ctx = _prepare(env, audit_retry_delay_s=0)
+    real = audit_stage._audit_one
+    prompts = sorted(p.stem for p in ctx.prompts_out_dir.glob("audit_*.md"))
+    victim = prompts[0]
+    calls: list[str] = []
+    monkeypatch.setattr(audit_stage, "_audit_one",
+                        _fake_audit_one({victim: 1}, calls, real))
+
+    do_audit(ctx)
+
+    # the focus was attempted twice and its findings artifact exists after the retry
+    assert calls.count(victim) == 2
+    produced = {p.stem.replace("audit_", "") for p in ctx.findings_dir.glob("audit_*.json")}
+    assert victim.replace("audit_", "") in produced
+    # coverage is complete: every planned focus produced an artifact
+    assert produced == {s.replace("audit_", "") for s in prompts}
+
+
+def test_a_malformed_answer_is_never_retried(env, monkeypatch):
+    """A findings file that does not parse is a RESULT. Retrying it would select on the output."""
+    ctx = _prepare(env, audit_retry_delay_s=0)
+    prompts = sorted(p.stem for p in ctx.prompts_out_dir.glob("audit_*.md"))
+    victim = prompts[0]
+    calls: list[str] = []
+
+    real = audit_stage._audit_one
+    monkeypatch.setattr(audit_stage, "_audit_one",
+                        lambda c, s, p: (p.stem, None, "findings file is not valid JSON: boom",
+                                         False) if p.stem == victim else real(c, s, p))
+    monkeypatch.setattr(audit_stage, "_log", lambda m: calls.append(m))
+
+    do_audit(ctx)
+    # exactly one attempt on the victim: it appears once in the SKIPPED log, never retried
+    assert sum(1 for m in calls if victim in str(m) and "SKIPPED" in str(m)) == 1
+    assert not any("retrying once" in str(m) for m in calls)
+
+
+def test_retry_is_bounded_at_one_extra_attempt(env, monkeypatch):
+    ctx = _prepare(env, audit_retry_delay_s=0)
+    prompts = sorted(p.stem for p in ctx.prompts_out_dir.glob("audit_*.md"))
+    victim = prompts[0]
+    calls: list[str] = []
+    real = audit_stage._audit_one
+    # never succeeds
+    monkeypatch.setattr(audit_stage, "_audit_one",
+                        _fake_audit_one({victim: 99}, calls, real))
+
+    do_audit(ctx)
+
+    assert calls.count(victim) == 2, "a permanently failing focus must not loop"
+    produced = {p.stem for p in ctx.findings_dir.glob("audit_*.json")}
+    assert victim not in produced   # and the gap is real, not papered over
+
+
+def test_retry_can_be_switched_off(env, monkeypatch):
+    ctx = _prepare(env, audit_retry_delay_s=0, audit_retry_passes=0)
+    prompts = sorted(p.stem for p in ctx.prompts_out_dir.glob("audit_*.md"))
+    victim = prompts[0]
+    calls: list[str] = []
+    real = audit_stage._audit_one
+    monkeypatch.setattr(audit_stage, "_audit_one",
+                        _fake_audit_one({victim: 1}, calls, real))
+
+    do_audit(ctx)
+
+    assert calls.count(victim) == 1, "audit_retry_passes=0 restores abandon-on-failure"
+
+
+def test_successful_focuses_are_untouched_by_the_retry_path(env, monkeypatch):
+    """The retry must not re-run focuses that already produced an artifact — that would double
+    the cost of every run in which any single focus blipped."""
+    ctx = _prepare(env, audit_retry_delay_s=0)
+    prompts = sorted(p.stem for p in ctx.prompts_out_dir.glob("audit_*.md"))
+    victim, others = prompts[0], prompts[1:]
+    calls: list[str] = []
+    real = audit_stage._audit_one
+    monkeypatch.setattr(audit_stage, "_audit_one",
+                        _fake_audit_one({victim: 1}, calls, real))
+
+    do_audit(ctx)
+
+    for slug in others:
+        assert calls.count(slug) == 1, f"{slug} succeeded and must not be re-run"


### PR DESCRIPTION
## The bug

Both backends can hit a transient limit inside the same minute. When that happens the focus session returns `exit_1` with **zero tokens, no session id and no partial artifact** — and `stages/audit.py` dropped that focus permanently, with no retry.

A run could therefore finish clean having audited **one of three focus areas**. That is worse than a visible failure: the finding count stops being a property of the target and becomes a property of *when the run happened to execute*, so two targets are no longer comparable.

Observed live:

```
[runner] backend #0 (codex) hit a retryable limit (unknown_retryable); falling back to #1
[audit]  audit_transformation-correctness: SKIPPED (session failed, no partial artifact ... exit_1)
[runner] backend #0 (codex) hit a retryable limit (unknown_retryable); falling back to #1
[audit]  audit_process-cache-output:       SKIPPED (session failed, no partial artifact ... exit_1)
[audit]  audit_architecture-integrity: 7 finding(s)
```

Both accounts answered a trivial `codex exec` normally minutes later, so the failure was transient — exactly the case a second attempt recovers.

## The fix

`_audit_one` now returns whether a failure is **retryable**, and the stage runs one extra pass over the focuses whose *session* never produced anything, after `audit_retry_delay_s` (90 s — long enough for a short backend backoff to clear).

- Bounded at one extra attempt; a permanently failing focus does not loop.
- `audit_retry_passes=0` restores the previous abandon-on-failure behaviour.
- Focuses that already produced an artifact are **not** re-run, so a single blip does not double the cost of the run.

## The line this holds

**Session failures are retried. Answers are not.**

A malformed or schema-invalid findings file is a *result* and stands. Re-rolling a focus until the model emits something parseable would be selecting on the output, which is a different and much worse thing than recovering from a transport failure.

## Tests

Five, including the two that keep the feature honest: a malformed answer is never retried, and successful focuses are untouched by the retry pass. Full suite: 480 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyetELzeNo4axNuKg6RRKW